### PR TITLE
fix(server): pass rtk --agent pi for omp hook init

### DIFF
--- a/apps/server/src/provider/omp/RtkManagedBinary.test.ts
+++ b/apps/server/src/provider/omp/RtkManagedBinary.test.ts
@@ -5,6 +5,7 @@ import {
   parseChecksumLine,
   parseRtkVersionOutput,
   resolveRtkReleaseAssetName,
+  RTK_OMP_HOOK_INIT_ARGS,
 } from "./RtkManagedBinary.ts";
 
 describe("RtkManagedBinary helpers", () => {
@@ -41,5 +42,12 @@ describe("RtkManagedBinary helpers", () => {
       ),
     ).toBe("abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1");
     expect(parseChecksumLine("not-a-checksum", "rtk-x86_64-unknown-linux-musl.tar.gz")).toBeNull();
+  });
+
+  it("activates the omp hook with rtk's current agent name (pi, not omp)", () => {
+    // rtk 0.45.0 dropped the `omp` --agent value (canonicalized to `pi`); a
+    // stale value makes `rtk init -g --agent omp` exit 2 and fail install.
+    expect([...RTK_OMP_HOOK_INIT_ARGS]).toEqual(["init", "-g", "--agent", "pi"]);
+    expect(RTK_OMP_HOOK_INIT_ARGS).not.toContain("omp");
   });
 });

--- a/apps/server/src/provider/omp/RtkManagedBinary.ts
+++ b/apps/server/src/provider/omp/RtkManagedBinary.ts
@@ -30,6 +30,11 @@ import { isLinuxMuslHost, normalizeReleaseVersion, platformKey } from "./OmpMana
 export const RTK_GITHUB_REPO = "rtk-ai/rtk";
 /** Cache key for ProviderVersionCache companion checks. */
 export const RTK_VERSION_CACHE_KEY = "github:rtk-ai/rtk";
+/**
+ * Args for `rtk init` hook activation. rtk 0.45.0 renamed the Oh My Pi agent
+ * value from `omp` to `pi`; keep in sync with rtk's `--agent` enum.
+ */
+export const RTK_OMP_HOOK_INIT_ARGS = ["init", "-g", "--agent", "pi"] as const;
 
 const INSTALL_LOCK_RETRY_COUNT = 100;
 const INSTALL_LOCK_RETRY_DELAY = "100 millis";
@@ -591,10 +596,10 @@ export const makeRtkManagedBinary = Effect.fn("rtkManagedBinary.make")(function*
         message: "Managed rtk is not available; cannot activate the omp rewrite hook.",
       });
     }
-    yield* runCommand(status.executablePath, ["init", "-g", "--agent", "omp"]).pipe(
+    yield* runCommand(status.executablePath, RTK_OMP_HOOK_INIT_ARGS).pipe(
       wrapInstallFailure(
         "validation_failed",
-        "Could not run `rtk init -g --agent omp` for the managed rtk binary.",
+        "Could not run `rtk init -g --agent pi` for the managed rtk binary.",
       ),
     );
   });

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -290,7 +290,7 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
         ),
       );
       return {
-        stdout: `Installed omp ${installed.version ?? "unknown"} at ${installed.executablePath}; rtk ${rtkInstalled.version ?? "unknown"} at ${rtkInstalled.executablePath}; ran rtk init -g --agent omp`,
+        stdout: `Installed omp ${installed.version ?? "unknown"} at ${installed.executablePath}; rtk ${rtkInstalled.version ?? "unknown"} at ${rtkInstalled.executablePath}; ran rtk init -g --agent pi`,
         stderr: "",
         exitCode: 0,
         timedOut: false,

--- a/docs/user/providers-omp.md
+++ b/docs/user/providers-omp.md
@@ -4,7 +4,7 @@ Pivot drives [omp](https://omp.sh) over `omp --mode rpc`. omp is the only built-
 
 ## Install
 
-1. Open **Settings → omp** and click **Install**. Pivot downloads a managed omp binary into the T3 home (`tools/omp/`), then downloads managed [rtk](https://github.com/rtk-ai/rtk) into `tools/rtk/` and runs `rtk init -g --agent omp` so bash rewrite hooks are active for omp.
+1. Open **Settings → omp** and click **Install**. Pivot downloads a managed omp binary into the T3 home (`tools/omp/`), then downloads managed [rtk](https://github.com/rtk-ai/rtk) into `tools/rtk/` and runs `rtk init -g --agent pi` so bash rewrite hooks are active for omp.
 2. Authenticate omp for the models you use (Settings → omp accounts, or `omp login` on the server host).
 
 When Pivot detects that managed omp **or** managed rtk is behind the latest GitHub release, Settings shows the same Update action. Updating refreshes both binaries and re-runs the omp hook init.


### PR DESCRIPTION
Settings → omp → Install was failing on the final step: after both managed binaries are downloaded, the post-install `rtk init -g --agent omp` exited 2 because rtk 0.45.0 renamed its Oh My Pi `--agent` value from `omp` to `pi` (T3's managed rtk install always fetches latest).

Extract the hook init argv into a tested `RTK_OMP_HOOK_INIT_ARGS` constant and pass `--agent pi`; update the error/stdout strings and the user doc. Adds a regression test asserting the exact argv and that `omp` is absent.

Verified: focused test 3/3, `rtk init -g --agent pi` exits 0 against the managed binary with an isolated `PI_CODING_AGENT_DIR`, targeted `pivot-cli` typecheck clean.

Model: opencode-go/deepseek-v4-flash; harness: omp