### PR TITLE
fix(server): correct omp context meter and streamed message joins

### DIFF
--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -197,6 +197,88 @@ describe("OmpAdapter", () => {
     }),
   );
 
+  it.effect("separates consecutive assistant messages with a paragraph break", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_start",
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "Fetching latest upstream." },
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_end",
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_start",
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "24 commits behind." },
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      const deltas = events
+        .filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        )
+        .map((event) => (event as { payload: { delta: string } }).payload.delta);
+      NodeAssert.deepEqual(deltas, ["Fetching latest upstream.", "\n\n24 commits behind."]);
+    }),
+  );
+
+  it.effect("tool-only assistant messages do not add paragraph breaks", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_start",
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_update",
+        assistantMessageEvent: { type: "toolcall_start" },
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_start",
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "first text" },
+        message: { role: "assistant", content: [] },
+      });
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      const deltas = events
+        .filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        )
+        .map((event) => (event as { payload: { delta: string } }).payload.delta);
+      NodeAssert.deepEqual(deltas, ["first text"]);
+    }),
+  );
+
   it.effect("ignores empty command_output text from local slash prompts", () =>
     Effect.gen(function* () {
       const fake = new FakeOmpRpc();
@@ -418,7 +500,7 @@ describe("OmpAdapter", () => {
   it.effect("emits thread token usage from get_state contextUsage on turn complete", () =>
     Effect.gen(function* () {
       const fake = new FakeOmpRpc();
-      fake.contextUsage = { tokens: 1100, contextWindow: 200_000, percent: 0.55 };
+      fake.contextUsage = { tokens: 1100, contextWindow: 200_000, percent: 55 };
       fake.tokensPerSecond = 42;
       fake.queuedMessageCount = 2;
       const adapter = new OmpAdapter(fake, testRandomUUID);
@@ -451,7 +533,7 @@ describe("OmpAdapter", () => {
   it.effect("emits live thread token usage during message_update", () =>
     Effect.gen(function* () {
       const fake = new FakeOmpRpc();
-      fake.contextUsage = { tokens: 500, contextWindow: 100_000, percent: 0.05 };
+      fake.contextUsage = { tokens: 500, contextWindow: 100_000, percent: 5 };
       fake.tokensPerSecond = 12.5;
       fake.queuedMessageCount = 1;
       const adapter = new OmpAdapter(fake, testRandomUUID);

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -116,6 +116,10 @@ interface LiveAdapterSession {
   stopRequested: boolean;
   /** Wall-clock ms of the last mid-turn token-usage emit (throttle). */
   lastTokenUsageEmitAtMs: number;
+  /** Whether any assistant text delta was emitted for the current turn. */
+  assistantTextEmitted: boolean;
+  /** An assistant message started while prior assistant text already exists. */
+  pendingAssistantMessageBoundary: boolean;
   interactionMode: ProviderInteractionMode;
   prePlanModelSlug: string | undefined;
   onOpenUrl: ((request: OmpOpenUrlRequest) => Effect.Effect<void>) | undefined;
@@ -214,6 +218,8 @@ export class OmpAdapter {
         stopRequested: false,
         // Negative so the first mid-turn emit is not throttled when Clock is 0 (TestClock).
         lastTokenUsageEmitAtMs: -TOKEN_USAGE_EMIT_MIN_INTERVAL_MS,
+        assistantTextEmitted: false,
+        pendingAssistantMessageBoundary: false,
         interactionMode: "default",
         prePlanModelSlug: undefined,
         onOpenUrl: undefined,
@@ -247,6 +253,8 @@ export class OmpAdapter {
       const turnId = yield* this.#randomUUID.pipe(Effect.map(TurnId.make));
       session.turnId = turnId;
       session.stopRequested = false;
+      session.assistantTextEmitted = false;
+      session.pendingAssistantMessageBoundary = false;
       yield* this.#applyInteractionMode(session, input.interactionMode);
       if (session.interactionMode !== "plan") {
         yield* this.#applyModelSelection(input.threadId, input.modelSelection?.model);
@@ -710,6 +718,9 @@ export class OmpAdapter {
     if (frame.type === "command_output") {
       return this.#onCommandOutput(session, frame);
     }
+    if (frame.type === "message_start") {
+      return this.#onMessageStart(session, frame);
+    }
     if (frame.type === "message_update") {
       return this.#onMessageUpdate(session, frame).pipe(
         Effect.tap(() =>
@@ -839,6 +850,20 @@ export class OmpAdapter {
     });
   }
 
+  #onMessageStart(
+    session: LiveAdapterSession,
+    frame: Record<string, unknown>,
+  ): Effect.Effect<void> {
+    const message = frame.message;
+    if (!isRecord(message) || message.role !== "assistant") {
+      return Effect.void;
+    }
+    if (session.assistantTextEmitted) {
+      session.pendingAssistantMessageBoundary = true;
+    }
+    return Effect.void;
+  }
+
   #onCommandOutput(
     session: LiveAdapterSession,
     frame: Record<string, unknown>,
@@ -847,6 +872,7 @@ export class OmpAdapter {
     if (text.length === 0) {
       return Effect.void;
     }
+    session.assistantTextEmitted = true;
     return this.#emit({
       type: "content.delta",
       threadId: session.threadId,
@@ -871,13 +897,22 @@ export class OmpAdapter {
       if (typeof delta !== "string" || delta.length === 0) {
         return Effect.void;
       }
+      // omp streams each assistant message as its own message_start/delta run.
+      // Without a boundary the status lines of consecutive messages concatenate
+      // into one unreadable blob (e.g. "fresh main.24 commits behind."). Insert a
+      // paragraph break before the first text of a message that follows earlier
+      // assistant text; tool-only messages leave the pending flag untouched so
+      // they never introduce a stray blank separator.
+      const boundary = session.pendingAssistantMessageBoundary ? "\n\n" : "";
+      session.pendingAssistantMessageBoundary = false;
+      session.assistantTextEmitted = true;
       return this.#emit({
         type: "content.delta",
         threadId: session.threadId,
         turnId: session.turnId,
         payload: {
           streamKind: "assistant_text",
-          delta,
+          delta: `${boundary}${delta}`,
         },
       });
     }
@@ -1082,7 +1117,7 @@ export class OmpAdapter {
           : undefined;
       const contextUsedPercent =
         typeof contextUsage.percent === "number" && Number.isFinite(contextUsage.percent)
-          ? Math.min(100, Math.max(0, Math.round(contextUsage.percent * 1000) / 10))
+          ? Math.min(100, Math.max(0, Math.round(contextUsage.percent * 10) / 10))
           : undefined;
       const tokensPerSecond =
         typeof state.tokensPerSecond === "number" && Number.isFinite(state.tokensPerSecond)


### PR DESCRIPTION
## Problem

Two omp-adapter bugs made the chat surface lie about what the agent was doing:

1. **Context window always showed 100%.** omp reports `contextUsage.percent` as 0–100, but the adapter scaled it as a 0–1 fraction (`* 1000`), so every reading clamped to 100. A session at 10.5% usage (105k/1M tokens) surfaced as 100%.
2. **Streamed agent text began as an unreadable blob.** omp streams each assistant message as its own `message_start` → `text_delta` run; the adapter ignored `message_start`, so status lines from consecutive messages concatenated with no separator (e.g. `fresh main.24 commits behind.`). The later `## What happened` section rendered fine — the blob was multiple messages welded together, not a markdown rendering failure.

## Fix

1. Treat `contextUsage.percent` as 0–100 (keep one-decimal rounding): `* 1000` → `* 10`.
2. Track per-turn assistant-message boundaries in the adapter: on assistant `message_start` after prior text, mark a pending boundary; the first `text_delta` of that message prepends a `\n\n` paragraph break. Tool-only messages add none, and the flags reset each turn.

## Verification

- 2 updated percent fixtures (55, 5) fail on the old clamp, pass now.
- 2 new tests: consecutive assistant messages emit `["Fetching latest upstream.", "\n\n24 commits behind."]`; tool-only-then-text emits no prefix.
- `vp test run apps/server/src/provider/omp/`: 7 files, 72/72 pass. Server typecheck exits 0 (only pre-existing style suggestions); lint clean for changed lines.
