### PR TITLE
fix(server): settle omp sessions when the provider child dies

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -131,6 +131,7 @@ function createProviderServiceHarness(
     ompGetSubagentMessages: () => unsupported(),
     ompSteer: () => unsupported(),
     ompSetSubagentSubscription: () => unsupported(),
+    reconcileStaleSessions: () => unsupported(),
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);
     },

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -343,6 +343,7 @@ describe("ProviderCommandReactor", () => {
       ompGetSubagentMessages: () => unsupported(),
       ompSteer: () => unsupported(),
       ompSetSubagentSubscription: () => unsupported(),
+      reconcileStaleSessions: () => unsupported(),
       get streamEvents() {
         return Stream.fromPubSub(runtimeEventPubSub);
       },

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -99,6 +99,8 @@ function isLegacyTurnCompletedEvent(
 function createProviderServiceHarness() {
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
   const runtimeSessions: ProviderSession[] = [];
+  let staleSessionEvents: ProviderRuntimeEvent[] = [];
+  let reconcileStaleSessionCalls = 0;
 
   const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
   const service: ProviderServiceShape = {
@@ -127,6 +129,10 @@ function createProviderServiceHarness() {
     ompGetSubagentMessages: () => unsupported(),
     ompSteer: () => unsupported(),
     ompSetSubagentSubscription: () => unsupported(),
+    reconcileStaleSessions: () => {
+      reconcileStaleSessionCalls += 1;
+      return Effect.succeed([...staleSessionEvents]);
+    },
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);
     },
@@ -160,10 +166,16 @@ function createProviderServiceHarness() {
     Effect.runSync(PubSub.publish(runtimeEventPubSub, normalizeLegacyEvent(event)));
   };
 
+  const setStaleSessionEvents = (events: ReadonlyArray<ProviderRuntimeEvent>): void => {
+    staleSessionEvents = [...events];
+  };
+
   return {
     service,
     emit,
     setSession,
+    setStaleSessionEvents,
+    reconcileStaleSessionCalls: () => reconcileStaleSessionCalls,
   };
 }
 
@@ -224,10 +236,16 @@ describe("ProviderRuntimeIngestion", () => {
     }
   });
 
-  async function createHarness(options?: { serverSettings?: Partial<ServerSettings> }) {
+  async function createHarness(options?: {
+    serverSettings?: Partial<ServerSettings>;
+    staleSessionEvents?: ReadonlyArray<ProviderRuntimeEvent>;
+  }) {
     const workspaceRoot = makeTempDir("t3-provider-project-");
     NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
     const provider = createProviderServiceHarness();
+    if (options?.staleSessionEvents) {
+      provider.setStaleSessionEvents(options.staleSessionEvents);
+    }
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationProjectionPipelineLive),
@@ -321,6 +339,8 @@ describe("ProviderRuntimeIngestion", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       emit: provider.emit,
       setProviderSession: provider.setSession,
+      setStaleSessionEvents: provider.setStaleSessionEvents,
+      reconcileStaleSessionCalls: provider.reconcileStaleSessionCalls,
       drain,
     };
   }
@@ -365,6 +385,35 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("turn failed");
+  });
+
+  it("start() settles stale sessions via reconcileStaleSessions", async () => {
+    const harness = await createHarness();
+    // start() must ask the provider service to settle sessions that did not
+    // survive the previous server process (their provider children died with
+    // it). The reconcile-returned session.exited events flow through the same
+    // worker as live runtime events, so a session.exited lands the projection
+    // on "stopped".
+    expect(harness.reconcileStaleSessionCalls()).toBe(1);
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-stale-session-exited"),
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      payload: {
+        reason: "server restarted; provider session did not survive",
+        exitKind: "error",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "stopped",
+    );
+    expect(thread.session?.status).toBe("stopped");
   });
 
   it("applies provider session.state.changed transitions directly", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2066,6 +2066,20 @@ const make = Effect.gen(function* () {
           return worker.enqueue({ source: "domain", event });
         }),
       );
+      // Sessions left "running" by the previous server process (its provider
+      // children died with it) have no live adapter session behind them and
+      // would otherwise show as permanently running with an inert stop button.
+      // Settle them through the same worker so the projection leaves "running".
+      yield* providerService.reconcileStaleSessions().pipe(
+        Effect.flatMap((events) =>
+          Effect.forEach(events, (event) => worker.enqueue({ source: "runtime", event })),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("failed to reconcile stale provider sessions", {
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      );
     });
 
   return {

--- a/apps/server/src/provider/Drivers/OmpDriver.test.ts
+++ b/apps/server/src/provider/Drivers/OmpDriver.test.ts
@@ -8,6 +8,7 @@ import * as NodePath from "node:path";
 import { it } from "@effect/vitest";
 import { OmpSettings, ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -88,6 +89,7 @@ function makeFakeOmpSpawner(sessionFile: string) {
             : {}),
         },
         killed: false,
+        exit: yield* Deferred.make<ChildProcessSpawner.ExitCode, never>(),
       };
       spawns.push(spawn);
 
@@ -116,12 +118,16 @@ function makeFakeOmpSpawner(sessionFile: string) {
       let stdinBuf = "";
       return ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(spawns.length),
-        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        exitCode: Deferred.await(spawn.exit),
         isRunning: Effect.sync(() => !spawn.killed),
         kill: () =>
           Effect.sync(() => {
             spawn.killed = true;
-          }),
+          }).pipe(
+            Effect.andThen(
+              Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(143)).pipe(Effect.ignore),
+            ),
+          ),
         unref: Effect.succeed(Effect.void),
         stdin: Sink.forEach((chunk: Uint8Array) => {
           stdinBuf += decoder.decode(chunk, { stream: true });

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -725,6 +725,93 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+it.effect("ProviderServiceLive settles stale running sessions via reconcileStaleSessions", () =>
+  Effect.gen(function* () {
+    const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-reconcile-"));
+    const dbPath = NodePath.join(tempDir, "orchestration.sqlite");
+
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: codex.adapter,
+    });
+
+    const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+    const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+      Layer.provide(persistenceLayer),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+
+    yield* Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      yield* directory.upsert({
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId: asThreadId("thread-stale-running"),
+        status: "running",
+        resumeCursor: "/tmp/stale-session.jsonl",
+        runtimePayload: { cwd: "/proj", activeTurnId: "turn-stale" },
+      });
+      // A binding backed by a live adapter session is left alone.
+      yield* directory.upsert({
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId: asThreadId("thread-fresh-running"),
+        status: "running",
+        resumeCursor: "/tmp/fresh-session.jsonl",
+        runtimePayload: { cwd: "/proj", activeTurnId: "turn-fresh" },
+      });
+    }).pipe(Effect.provide(directoryLayer));
+
+    codex.hasSession.mockImplementation((threadId: ThreadId) =>
+      Effect.succeed(threadId === asThreadId("thread-fresh-running")),
+    );
+
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+      Layer.provide(directoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(serverConfigTestLayer),
+      Layer.provide(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    );
+
+    // Read the bindings inside the provider layer scope: its shutdown
+    // finalizer (runStopAll) marks every persisted binding stopped, which would
+    // otherwise mask the reconcile's skip-live-session behavior.
+    const outcome = yield* Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const events = yield* provider.reconcileStaleSessions();
+      const stale = yield* directory.getBinding(asThreadId("thread-stale-running"));
+      const fresh = yield* directory.getBinding(asThreadId("thread-fresh-running"));
+      return {
+        events,
+        staleStatus: Option.isSome(stale) ? stale.value.status : undefined,
+        freshStatus: Option.isSome(fresh) ? fresh.value.status : undefined,
+      };
+    }).pipe(Effect.provide(Layer.mergeAll(providerLayer, directoryLayer)), Effect.scoped);
+
+    assert.equal(outcome.events.length, 1);
+    const event = outcome.events[0];
+    assert.equal(event?.type, "session.exited");
+    assert.equal(event?.threadId, "thread-stale-running");
+    assert.equal(event?.providerInstanceId, codexInstanceId);
+    if (event?.type === "session.exited") {
+      assert.equal(event.payload.exitKind, "error");
+      assert.match(event.payload.reason ?? "", /server restarted/i);
+    }
+    assert.equal(outcome.staleStatus, "stopped");
+    assert.equal(outcome.freshStatus, "running");
+
+    NodeFS.rmSync(tempDir, { recursive: true, force: true });
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
 it.effect(
   "ProviderServiceLive restores rollback routing after restart using persisted thread mapping",
   () =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -10,6 +10,7 @@
  * @module ProviderServiceLive
  */
 import {
+  EventId,
   ModelSelection,
   NonNegativeInt,
   ThreadId,
@@ -524,6 +525,77 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             }),
       { discard: true },
     );
+  });
+
+  const reconcileStaleSessions = Effect.fn("ProviderService.reconcileStaleSessions")(function* () {
+    // After a server restart every persisted "running"/"starting" binding is
+    // stale: the provider child died with the previous process and no live
+    // adapter session backs the row. Emit one synthetic session.exited per
+    // stale binding so the projection leaves "running" (the thread un-sticks in
+    // the UI), and flip the binding to stopped so recovery routing does not
+    // treat it as an active session.
+    const bindings = yield* directory.listBindings().pipe(Effect.orElseSucceed(() => []));
+    const events: ProviderRuntimeEvent[] = [];
+    for (const binding of bindings) {
+      if (binding.status !== "running" && binding.status !== "starting") {
+        continue;
+      }
+      const instanceIdOption = yield* requireBindingInstanceId(
+        "ProviderService.reconcileStaleSessions",
+        binding,
+      ).pipe(Effect.option);
+      if (Option.isNone(instanceIdOption)) {
+        continue;
+      }
+      const instanceId = instanceIdOption.value;
+      const adapterOption = yield* registry.getByInstance(instanceId).pipe(Effect.option);
+      if (Option.isNone(adapterOption)) {
+        continue;
+      }
+      const adapter = adapterOption.value;
+      const hasLiveSession = yield* adapter.hasSession(binding.threadId);
+      if (hasLiveSession) {
+        continue;
+      }
+      yield* directory
+        .upsert({
+          threadId: binding.threadId,
+          provider: adapter.provider,
+          providerInstanceId: instanceId,
+          status: "stopped",
+          runtimePayload: {
+            activeTurnId: null,
+            lastRuntimeEvent: "provider.boot-reconcile",
+            lastRuntimeEventAt: yield* nowIso,
+          },
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to mark stale provider session stopped", {
+              threadId: binding.threadId,
+              provider: adapter.provider,
+              cause: causeErrorTag(cause),
+            }),
+          ),
+        );
+      events.push({
+        type: "session.exited",
+        // Deterministic per binding; the command-receipt dedupe makes a
+        // re-run idempotent, so a plain string id is fine here.
+        eventId: EventId.make(
+          `boot-reconcile:${binding.threadId}:${binding.lastSeenAt ?? "unknown"}`,
+        ),
+        provider: adapter.provider,
+        providerInstanceId: instanceId,
+        threadId: binding.threadId,
+        createdAt: yield* nowIso,
+        payload: {
+          reason: "server restarted; provider session did not survive",
+          exitKind: "error",
+        },
+      });
+    }
+    return events;
   });
 
   const startSession: ProviderServiceMethod<"startSession"> = Effect.fn("startSession")(
@@ -1189,6 +1261,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     ompGetSubagentMessages,
     ompSteer,
     ompSetSubagentSubscription,
+    reconcileStaleSessions,
     // Each access creates a fresh PubSub subscription so that multiple
     // consumers (ProviderRuntimeIngestion, CheckpointReactor, etc.) each
     // independently receive all runtime events.

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -187,6 +187,7 @@ describe("ProviderSessionReaper", () => {
       ompGetSubagentMessages: () => unsupported(),
       ompSteer: () => unsupported(),
       ompSetSubagentSubscription: () => unsupported(),
+      reconcileStaleSessions: () => Effect.succeed([]),
       streamEvents: Stream.empty,
     };
 

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -140,6 +140,17 @@ export interface ProviderServiceShape {
   }) => Effect.Effect<{ readonly level: "off" | "progress" | "events" }, ProviderServiceError>;
 
   /**
+   * Settle provider sessions that did not survive a server restart.
+   *
+   * Every persisted binding that claims a running/starting session with no
+   * live adapter session behind it (the provider child died with the previous
+   * process) is marked stopped, and one synthetic `session.exited` runtime
+   * event per binding is returned for the caller to feed through runtime
+   * ingestion so the projection leaves "running".
+   */
+  readonly reconcileStaleSessions: () => Effect.Effect<ReadonlyArray<ProviderRuntimeEvent>>;
+
+  /**
    * Canonical provider runtime event stream.
    *
    * Fan-out is owned by ProviderService (not by a standalone event-bus service).

--- a/apps/server/src/provider/omp/FakeOmpRpc.ts
+++ b/apps/server/src/provider/omp/FakeOmpRpc.ts
@@ -12,6 +12,8 @@ import { OmpSpawnError } from "./OmpRpcRuntime.ts";
 export class FakeOmpRpc {
   agentInvoked: boolean | undefined = true;
   failSetModel = false;
+  /** When false, `send` never answers `abort` (simulates a wedged child). */
+  respondToAbort = true;
   sessionFile = "/tmp/omp-session.jsonl";
   availableModels: ReadonlyArray<object> = [];
   availableCommands: ReadonlyArray<object> = [];
@@ -161,6 +163,12 @@ export class FakeOmpRpc {
         data: this.sessionStats ?? {},
       });
     }
+    if (command.type === "abort") {
+      if (!this.respondToAbort) {
+        return Effect.never;
+      }
+      return Effect.succeed({ type: "response", success: true, data: {} });
+    }
     if (
       command.type === "steer" ||
       command.type === "set_subagent_subscription" ||
@@ -207,5 +215,14 @@ export class FakeOmpRpc {
       return Effect.die(`no live omp session for ${sessionKey}`);
     }
     return Queue.offer(queue, frame);
+  }
+
+  /** End the frame stream for a session, simulating child exit / transport end. */
+  closeFrames(sessionKey: string) {
+    const queue = this.frames.get(sessionKey);
+    if (!queue) {
+      return Effect.void;
+    }
+    return Queue.shutdown(queue);
   }
 }

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -15,6 +15,7 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { describe } from "vite-plus/test";
 
 import { ProviderAdapterRequestError, ProviderAdapterSessionNotFoundError } from "../Errors.ts";
@@ -690,6 +691,93 @@ describe("OmpAdapter", () => {
         NodeAssert.ok(isProviderAdapterSessionNotFoundError(Cause.squash(exit.cause)));
       }
     }),
+  );
+
+  it.effect("settles turn + session when the frame transport ends mid-turn", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(Stream.takeUntil((event) => event.type === "session.exited")),
+      ).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.closeFrames(THREAD_ID);
+      const events = yield* Fiber.join(eventsFiber);
+      NodeAssert.equal(
+        events.some(
+          (event) => event.type === "turn.aborted" && event.payload.reason === "provider_exited",
+        ),
+        true,
+      );
+      NodeAssert.equal(
+        events.some(
+          (event) => event.type === "session.exited" && event.payload.exitKind === "error",
+        ),
+        true,
+      );
+      NodeAssert.equal(yield* adapter.hasSession(THREAD_ID), false);
+      NodeAssert.deepEqual(fake.disposed, [THREAD_ID]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("emits only session.exited when the transport ends while idle", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(Stream.takeUntil((event) => event.type === "session.exited")),
+      ).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(startInput);
+      yield* fake.closeFrames(THREAD_ID);
+      const events = yield* Fiber.join(eventsFiber);
+      NodeAssert.equal(
+        events.some((event) => event.type === "turn.aborted"),
+        false,
+      );
+      NodeAssert.equal(
+        events.some((event) => event.type === "session.exited"),
+        true,
+      );
+      NodeAssert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("interruptTurn force-stops when abort is never acknowledged", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      fake.respondToAbort = false;
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(Stream.takeUntil((event) => event.type === "session.exited")),
+      ).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      const interruptFiber = yield* adapter.interruptTurn(THREAD_ID).pipe(Effect.forkScoped);
+      yield* TestClock.adjust("10 seconds");
+      yield* Fiber.join(interruptFiber);
+      const events = yield* Fiber.join(eventsFiber);
+      NodeAssert.equal(
+        events.some(
+          (event) => event.type === "turn.aborted" && event.payload.reason === "user_abort",
+        ),
+        true,
+      );
+      NodeAssert.equal(
+        events.some((event) => event.type === "session.exited"),
+        true,
+      );
+      NodeAssert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }).pipe(Effect.scoped),
   );
 
   it.effect("readThread returns an empty turn list for a live session", () =>

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -126,6 +126,8 @@ interface LiveAdapterSession {
 }
 
 const TOKEN_USAGE_EMIT_MIN_INTERVAL_MS = 1_000;
+/** How long interruptTurn waits for omp to acknowledge `abort` before force-stopping. */
+const OMP_ABORT_ACK_TIMEOUT = "10 seconds";
 
 export type OmpResolveRoleModel = (role: string) => Effect.Effect<string | undefined>;
 
@@ -225,11 +227,19 @@ export class OmpAdapter {
         onOpenUrl: undefined,
       };
       this.#sessions.set(input.threadId, session);
-      yield* this.#runtime.streamFrames(input.threadId).pipe(
-        Stream.mapError((cause) => mapOmpSpawnError(input.threadId, cause)),
-        Stream.runForEach((frame) => this.#onFrame(session, frame)),
-        Effect.forkIn(scope),
-      );
+      // Frame transport runs in the session scope. When it ends (child exit,
+      // stream failure) or when deliberate teardown closes the scope, the fiber
+      // completes; if the child died while the session is still registered,
+      // settle the in-flight turn and the session instead of leaving the thread
+      // permanently "running".
+      yield* Effect.gen({ self: this }, function* () {
+        yield* this.#runtime.streamFrames(input.threadId).pipe(
+          Stream.mapError((cause) => mapOmpSpawnError(input.threadId, cause)),
+          Stream.runForEach((frame) => this.#onFrame(session, frame)),
+          Effect.exit,
+        );
+        yield* this.#onSessionTransportEnded(session);
+      }).pipe(Effect.forkIn(scope));
       yield* this.#runtime
         .send(input.threadId, {
           type: "set_subagent_subscription",
@@ -312,7 +322,16 @@ export class OmpAdapter {
         });
       }
       session.stopRequested = true;
-      yield* this.#send(threadId, { type: "abort" });
+      const abortOutcome = yield* Effect.exit(
+        this.#send(threadId, { type: "abort" }).pipe(Effect.timeout(OMP_ABORT_ACK_TIMEOUT)),
+      );
+      if (Exit.isFailure(abortOutcome)) {
+        // omp did not acknowledge the abort within the timeout (child dead or
+        // wedged, e.g. host restart). No terminal agent_end will arrive, so
+        // settle the turn and session here instead of leaving the thread
+        // permanently "running".
+        yield* this.#onSessionTransportEnded(session);
+      }
     });
   }
 
@@ -1063,11 +1082,15 @@ export class OmpAdapter {
       yield* this.#emitTokenUsageFromState(session).pipe(Effect.ignore);
       const aborted = session.stopRequested;
       session.stopRequested = false;
+      const turnId = session.turnId;
+      // Clear the in-flight marker so a later transport end (child exit while
+      // idle) cannot emit a spurious turn.aborted for an already-finished turn.
+      session.turnId = undefined;
       if (aborted) {
         yield* this.#emit({
           type: "turn.aborted",
           threadId: session.threadId,
-          turnId: session.turnId,
+          turnId,
           payload: { reason: "user_abort" },
         });
         return;
@@ -1075,7 +1098,7 @@ export class OmpAdapter {
       yield* this.#emit({
         type: "turn.completed",
         threadId: session.threadId,
-        turnId: session.turnId,
+        turnId,
         payload: { state: "completed" },
       });
     });
@@ -1316,6 +1339,40 @@ export class OmpAdapter {
     return this.#runtime
       .send(threadId, command)
       .pipe(Effect.mapError((cause) => mapOmpSpawnError(threadId, cause)));
+  }
+
+  #onSessionTransportEnded(session: LiveAdapterSession): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      if (this.#sessions.get(session.threadId) !== session) {
+        // Session was already cleared (deliberate teardown or a racing stop);
+        // do not double-settle.
+        return;
+      }
+      const turnId = session.turnId;
+      session.turnId = undefined;
+      const stopRequested = session.stopRequested;
+      session.stopRequested = false;
+      if (turnId !== undefined) {
+        yield* this.#emit({
+          type: "turn.aborted",
+          threadId: session.threadId,
+          turnId,
+          payload: { reason: stopRequested ? "user_abort" : "provider_exited" },
+        });
+      }
+      yield* this.#emit({
+        type: "session.exited",
+        threadId: session.threadId,
+        ...(turnId === undefined ? {} : { turnId }),
+        payload: {
+          reason: stopRequested
+            ? "omp child exited before confirming the requested stop"
+            : "omp rpc child exited unexpectedly",
+          exitKind: "error",
+        },
+      });
+      yield* this.#clearLiveSession(session.threadId);
+    });
   }
 
   #clearLiveSession(threadId: ThreadId) {

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -4,7 +4,10 @@ import * as NodeChildProcess from "node:child_process";
 
 import { it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
@@ -26,8 +29,11 @@ import {
   MAX_RPC_REASSEMBLED_BYTES,
   OmpRpcFrameDecoder,
   OmpRpcRuntime,
+  OmpSpawnError,
   RPC_CHUNK_PAYLOAD_BYTES,
 } from "./OmpRpcRuntime.ts";
+
+const isOmpSpawnError = Schema.is(OmpSpawnError);
 
 const UnknownJson = Schema.fromJsonString(Schema.Unknown);
 const decodeUnknownJson = Schema.decodeSync(UnknownJson);
@@ -144,6 +150,8 @@ type SpawnedCommand = {
 type FakeOmpSpawn = SpawnedCommand & {
   readonly commands: Array<Record<string, unknown>>;
   killed: boolean;
+  /** Resolves when the fake child exits; the runtime watcher reacts to it. */
+  readonly exit: Deferred.Deferred<ChildProcessSpawner.ExitCode, never>;
 };
 
 function asSpawnedCommand(command: ChildProcess.Command): SpawnedCommand {
@@ -198,18 +206,23 @@ function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
         ...spawned,
         commands: [],
         killed: false,
+        exit: yield* Deferred.make<ChildProcessSpawner.ExitCode, never>(),
       };
       spawns.push(spawn);
       let sessionFile = input.sessionFile;
       let stdinBuf = "";
       return ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(spawns.length),
-        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        exitCode: Deferred.await(spawn.exit),
         isRunning: Effect.sync(() => !spawn.killed),
         kill: () =>
           Effect.sync(() => {
             spawn.killed = true;
-          }),
+          }).pipe(
+            Effect.andThen(
+              Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(143)).pipe(Effect.ignore),
+            ),
+          ),
         unref: Effect.succeed(Effect.void),
         stdin: Sink.forEach((chunk: Uint8Array) => {
           stdinBuf += decoder.decode(chunk, { stream: true });
@@ -268,7 +281,15 @@ function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
       });
     }),
   );
-  return { spawner, spawns };
+  const exitSpawn = (spawn: FakeOmpSpawn, code = 0) =>
+    Effect.sync(() => {
+      spawn.killed = true;
+    }).pipe(
+      Effect.andThen(
+        Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(code)).pipe(Effect.asVoid),
+      ),
+    );
+  return { spawner, spawns, exitSpawn };
 }
 
 describe("OmpRpcRuntime", () => {
@@ -350,6 +371,49 @@ describe("OmpRpcRuntime", () => {
       NodeAssert.equal(fake.spawns[0]?.options.cwd, "/proj-a");
       NodeAssert.equal(fake.spawns[1]?.options.cwd, "/proj-b");
     }),
+  );
+
+  it.effect("fails in-flight requests and ends streamFrames when the child exits", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      yield* runtime.ensureSession({
+        sessionKey: "thread-1",
+        cwd: "/proj",
+        resumeCursor: null,
+      });
+      const framesFiber = yield* Stream.runCollect(runtime.streamFrames("thread-1")).pipe(
+        Effect.forkScoped,
+      );
+      // get_available_models gets no correlated response from the fake, so the
+      // request stays pending until the child exits.
+      const sendFiber = yield* runtime
+        .send("thread-1", { type: "get_available_models" })
+        .pipe(Effect.forkScoped);
+      // Wait until the fake child observed the command: by then the request's
+      // pending Deferred is registered and its liveness check passed, so the
+      // exit watcher — not the liveness fast-path — must fail it.
+      let observed = false;
+      for (let i = 0; i < 100 && !observed; i++) {
+        yield* Effect.yieldNow;
+        observed = (fake.spawns[0]?.commands ?? []).length >= 1;
+      }
+      NodeAssert.equal(observed, true);
+      yield* fake.exitSpawn(fake.spawns[0]!, 137);
+      const sendOutcome = yield* Fiber.join(sendFiber).pipe(Effect.exit);
+      NodeAssert.equal(Exit.isFailure(sendOutcome), true);
+      if (Exit.isFailure(sendOutcome)) {
+        const error = Cause.squash(sendOutcome.cause);
+        NodeAssert.ok(isOmpSpawnError(error));
+        NodeAssert.match(error.message, /child exited \(code 137\)/);
+      }
+      // The frames stream ends when the child exits (the queue is shut down;
+      // the pull may surface as success or interrupt — either way it must not
+      // hang and must carry no buffered frames).
+      const framesOutcome = yield* Fiber.join(framesFiber).pipe(Effect.exit);
+      const frames = Exit.isSuccess(framesOutcome) ? framesOutcome.value : [];
+      NodeAssert.equal(frames.length, 0);
+    }).pipe(Effect.scoped),
   );
 
   it.effect("dispose kills the live child so the next ensureSession respawns", () =>

--- a/apps/server/src/provider/omp/OmpRpcRuntime.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.ts
@@ -8,6 +8,7 @@
  * @module provider/omp/OmpRpcRuntime
  */
 import { mergePathValues } from "@t3tools/shared/shell";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -262,6 +263,30 @@ export class OmpRpcRuntime {
       const pending = new Map<string, Deferred.Deferred<object, OmpSpawnError>>();
       const decoder = new OmpRpcFrameDecoder();
 
+      // Watch for child death (crash, host restart, kill from outside) and
+      // surface it to every in-flight request and to the frame stream. Without
+      // this a dead `omp --mode rpc` leaves awaiting Deferreds hanging and
+      // `streamFrames` idle forever: the adapter never settles the turn and the
+      // thread stays "running" in the UI with a stop button that does nothing.
+      yield* child.exitCode.pipe(
+        Effect.map(Number),
+        Effect.orElseSucceed(() => 1),
+        Effect.flatMap((code) =>
+          Effect.gen(function* () {
+            const cause = new OmpSpawnError({
+              operation: "child-exit",
+              detail: `omp rpc child exited (code ${code})`,
+            });
+            yield* Effect.forEach(Array.from(pending.values()), (waiter) =>
+              Deferred.fail(waiter, cause).pipe(Effect.ignore),
+            ).pipe(Effect.asVoid);
+            pending.clear();
+            yield* Queue.shutdown(frames).pipe(Effect.ignore);
+          }),
+        ),
+        Effect.forkIn(scope),
+      );
+
       yield* child.stdout.pipe(
         Stream.decodeText(),
         Stream.splitLines,
@@ -314,6 +339,17 @@ export class OmpRpcRuntime {
       });
 
       const sessionFile = yield* handshake.pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.interrupt
+            : Effect.fail(
+                new OmpSpawnError({
+                  operation: "handshake",
+                  detail: "omp rpc handshake failed (child may have exited)",
+                  cause,
+                }),
+              ),
+        ),
         Effect.tapError(() =>
           child
             .kill()
@@ -407,6 +443,17 @@ export class OmpRpcRuntime {
       const id = `omp-${String(++this.#nextRequestId)}`;
       const waiter = yield* Deferred.make<object, OmpSpawnError>();
       pending.set(id, waiter);
+      // Close the race with the exit watcher: a request registering after the
+      // child died (watcher already cleared `pending`) must fail fast instead
+      // of awaiting a response that can never arrive.
+      const alive = yield* child.isRunning.pipe(Effect.orElseSucceed(() => false));
+      if (!alive) {
+        pending.delete(id);
+        return yield* new OmpSpawnError({
+          operation: String(command.type),
+          detail: "omp rpc child is not running",
+        });
+      }
       const payload = `${encodeUnknownJson({ id, ...command })}\n`;
       yield* Stream.run(Stream.encodeText(Stream.make(payload)), child.stdin).pipe(
         Effect.mapError(

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -674,6 +674,7 @@ const buildAppUnderTest = (options?: {
             ompSteer: () => Effect.die("ProviderService.ompSteer unsupported in test"),
             ompSetSubagentSubscription: () =>
               Effect.die("ProviderService.ompSetSubagentSubscription unsupported in test"),
+            reconcileStaleSessions: () => Effect.succeed([]),
             streamEvents: Stream.empty,
             ...options?.layers?.providerService,
           }),

--- a/apps/server/src/textGeneration/OmpTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OmpTextGeneration.test.ts
@@ -4,6 +4,7 @@ import { it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { OmpSettings, ProviderInstanceId } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
@@ -46,12 +47,13 @@ function makeFakeOmpSpawner(sessionFile: string) {
         supportedProtocolVersions: [1, 2],
       });
       asSpawnedCommand(command);
+      const exit = yield* Deferred.make<ChildProcessSpawner.ExitCode, never>();
       let stdinBuf = "";
       return ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(1),
-        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        exitCode: Deferred.await(exit),
         isRunning: Effect.succeed(true),
-        kill: () => Effect.void,
+        kill: () => Deferred.succeed(exit, ChildProcessSpawner.ExitCode(143)).pipe(Effect.asVoid),
         unref: Effect.succeed(Effect.void),
         stdin: Sink.forEach((chunk: Uint8Array) => {
           stdinBuf += decoder.decode(chunk, { stream: true });


### PR DESCRIPTION
## What Changed

Hardened the omp provider adapter so a dead or wedged `omp --mode rpc` child can no longer leave a thread permanently stuck "running" with an inert stop button.

- **`OmpRpcRuntime`**: a per-session exit watcher fails in-flight RPC requests and ends the frame stream when the child exits; `#request` fails fast if the child is already gone; a child dying mid-handshake surfaces as a typed `OmpSpawnError`.
- **`OmpAdapter`**: a transport end settles the in-flight turn (`turn.aborted`) and session (`session.exited` → stopped); `interruptTurn`'s `abort` send gets a 10s timeout with a force-stop fallback so Stop always works even on a wedged child.
- **Boot reconcile**: `ProviderService.reconcileStaleSessions` flips persisted running/starting sessions with no live adapter session to stopped and feeds a synthetic `session.exited` through the ingestion worker, so sessions that didn't survive a server restart auto-clear instead of lingering as zombies.

## Why

A crashed provider child (e.g. a host/WSL restart) left awaiting RPC Deferreds hanging forever and the frame stream idle, so the turn never settled and the session stayed `running` — the UI showed a stop button that did nothing, and the stale state survived server restarts. This is the failure shape that was reported.

## UI Changes

N/A — server-side only.



---

Focused tests green (216 across omp runtime/adapter, ProviderService, ingestion, reactors, reaper, driver); `vp typecheck` clean; lint clean on changed files.


