### PR TITLE
fix(server): claim token-usage throttle slot before emit to stop duplicate events

### DIFF
--- a/apps/server/src/provider/omp/FakeOmpRpc.ts
+++ b/apps/server/src/provider/omp/FakeOmpRpc.ts
@@ -3,6 +3,7 @@
  *
  * @module FakeOmpRpc
  */
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
@@ -14,6 +15,8 @@ export class FakeOmpRpc {
   failSetModel = false;
   /** When false, `send` never answers `abort` (simulates a wedged child). */
   respondToAbort = true;
+  /** When set, `get_state` responses are held until this resolves (throttle-race tests). */
+  getStateGate: Deferred.Deferred<void> | undefined = undefined;
   sessionFile = "/tmp/omp-session.jsonl";
   availableModels: ReadonlyArray<object> = [];
   availableCommands: ReadonlyArray<object> = [];
@@ -122,7 +125,7 @@ export class FakeOmpRpc {
       });
     }
     if (command.type === "get_state") {
-      return Effect.succeed({
+      const response = {
         type: "response",
         success: true,
         data: {
@@ -134,7 +137,10 @@ export class FakeOmpRpc {
             ? {}
             : { queuedMessageCount: this.queuedMessageCount }),
         },
-      });
+      };
+      return this.getStateGate === undefined
+        ? Effect.succeed(response)
+        : Deferred.await(this.getStateGate).pipe(Effect.as(response));
     }
     if (command.type === "get_subagent_messages") {
       return Effect.succeed({

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -10,6 +10,7 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -44,6 +45,17 @@ const collectUntilTurnCompleted = (stream: Stream.Stream<ProviderRuntimeEvent>) 
   Stream.runCollect(stream.pipe(Stream.takeUntil((event) => event.type === "turn.completed"))).pipe(
     Effect.map((chunk) => Array.from(chunk)),
   );
+
+/** Cooperative wait: spins `yieldNow` until the fake has recorded a matching send. */
+const waitForSent = (
+  fake: FakeOmpRpc,
+  predicate: (sent: ReadonlyArray<Record<string, unknown>>) => boolean,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    while (!predicate(fake.sent)) {
+      yield* Effect.yieldNow;
+    }
+  });
 
 describe("OmpAdapter", () => {
   it.effect("completes a T3 turn on terminal agent_end", () =>
@@ -570,6 +582,103 @@ describe("OmpAdapter", () => {
         true,
       );
     }),
+  );
+
+  it.effect(
+    "emits exactly one live token-usage event when concurrent message_update forks race the throttle guard",
+    () =>
+      Effect.gen(function* () {
+        const fake = new FakeOmpRpc();
+        fake.contextUsage = { tokens: 500, contextWindow: 100_000, percent: 5 };
+        const gate = yield* Deferred.make<void>();
+        const adapter = new OmpAdapter(fake, testRandomUUID);
+        const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.startSession(startInput);
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+        fake.getStateGate = gate; // set after sendTurn: the prompt command is not gated
+        yield* fake.offer(THREAD_ID, {
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "a" },
+        });
+        yield* fake.offer(THREAD_ID, {
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "b" },
+        });
+        // Let the detached forks reach their first send; the get_state responses are held at the gate.
+        yield* waitForSent(fake, (sent) => sent.some((c) => c.type === "get_state"));
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        // AC2: exactly one fiber passed the guard, so exactly one get_state was sent.
+        NodeAssert.equal(fake.sent.filter((c) => c.type === "get_state").length, 1);
+        // Release: the claiming fiber emits; a loser (pre-fix code) emits too.
+        yield* Deferred.succeed(gate, void 0);
+        yield* waitForSent(fake, (sent) => sent.some((c) => c.type === "get_session_stats"));
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        fake.contextUsage = undefined; // turn-complete emit becomes a no-op
+        yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+        const events = yield* Fiber.join(eventsFiber);
+        // AC1: exactly one live usage event. Pre-fix this is 2 (both fibers emitted).
+        NodeAssert.equal(
+          events.filter((event) => event.type === "thread.token-usage.updated").length,
+          1,
+        );
+      }),
+  );
+
+  it.effect(
+    "throttles live token-usage emits to one per second and re-enables after the window",
+    () =>
+      Effect.gen(function* () {
+        const fake = new FakeOmpRpc();
+        fake.contextUsage = { tokens: 500, contextWindow: 100_000, percent: 5 };
+        const adapter = new OmpAdapter(fake, testRandomUUID);
+        const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.startSession(startInput);
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+        // Virtual time 0: session init is -1000, so the first guard passes.
+        yield* fake.offer(THREAD_ID, {
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "a" },
+        });
+        yield* waitForSent(
+          fake,
+          (sent) => sent.filter((c) => c.type === "get_session_stats").length >= 1,
+        );
+        // In-window frame: suppressed (same virtual ms).
+        yield* fake.offer(THREAD_ID, {
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "b" },
+        });
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        NodeAssert.equal(fake.sent.filter((c) => c.type === "get_state").length, 1);
+        // Window elapses -> next frame emits again.
+        yield* TestClock.adjust("1 second");
+        yield* Effect.yieldNow;
+        yield* fake.offer(THREAD_ID, {
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "c" },
+        });
+        yield* waitForSent(
+          fake,
+          (sent) => sent.filter((c) => c.type === "get_session_stats").length >= 2,
+        );
+        // AC2: only the "a" and "c" frames passed the window guard.
+        NodeAssert.equal(fake.sent.filter((c) => c.type === "get_state").length, 2);
+        yield* Effect.yieldNow;
+        yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+        const events = yield* Fiber.join(eventsFiber);
+        // Live emits for "a" and "c" plus the unthrottled turn-complete snapshot.
+        NodeAssert.equal(
+          events.filter((event) => event.type === "thread.token-usage.updated").length,
+          3,
+        );
+      }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("lists a started session and reports hasSession", () =>

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -1079,7 +1079,8 @@ export class OmpAdapter {
 
   #emitTurnCompleted(session: LiveAdapterSession): Effect.Effect<void> {
     return Effect.gen({ self: this }, function* () {
-      yield* this.#emitTokenUsageFromState(session).pipe(Effect.ignore);
+      const now = yield* Clock.currentTimeMillis;
+      yield* this.#emitTokenUsageFromState(session, now).pipe(Effect.ignore);
       const aborted = session.stopRequested;
       session.stopRequested = false;
       const turnId = session.turnId;
@@ -1113,14 +1114,18 @@ export class OmpAdapter {
       if (now - session.lastTokenUsageEmitAtMs < TOKEN_USAGE_EMIT_MIN_INTERVAL_MS) {
         return;
       }
-      yield* this.#emitTokenUsageFromState(session).pipe(Effect.ignore);
+      yield* this.#emitTokenUsageFromState(session, now).pipe(Effect.ignore);
     });
   }
 
   #emitTokenUsageFromState(
     session: LiveAdapterSession,
+    now: number,
   ): Effect.Effect<void, ProviderAdapterProcessError | ProviderAdapterSessionNotFoundError> {
     return Effect.gen({ self: this }, function* () {
+      // D2/D3: claim the throttle slot synchronously, before any RPC yield. The
+      // slot is consumed even if the emit later fails or early-returns (no tokens).
+      session.lastTokenUsageEmitAtMs = now;
       const response = yield* this.#send(session.threadId, { type: "get_state" });
       if (!isRecord(response) || !isRecord(response.data)) {
         return;
@@ -1158,7 +1163,6 @@ export class OmpAdapter {
           ? statsResponse.data
           : undefined;
       const tokens = stats !== undefined && isRecord(stats.tokens) ? stats.tokens : undefined;
-      session.lastTokenUsageEmitAtMs = yield* Clock.currentTimeMillis;
       yield* this.#emit({
         type: "thread.token-usage.updated",
         threadId: session.threadId,


### PR DESCRIPTION
## Problem

Duplicate `thread.token-usage.updated` events land in the same millisecond. Every omp `message_update` forks a detached usage check, and the 1s throttle guard only updated `lastTokenUsageEmitAtMs` **after** the awaited `get_state`/`get_session_stats` RPCs — so concurrent forks all read the stale timestamp, all passed the guard, and all emitted.

## Fix

`#emitTokenUsageFromState` now claims the throttle slot synchronously as its first statement (`session.lastTokenUsageEmitAtMs = now`), before any RPC yield, using the guard's `now`. The end-of-function mark is deleted. There is no suspension between the guard check and the claim, so check-and-mark is atomic: whichever fork runs first wins, exactly one emit per throttle decision. Turn-complete snapshot stays unthrottled (D5) but shares the claim.

## Verification

- T1 regression: two same-ms `message_update` forks with `get_state` held on a Deferred gate — exactly 1 `get_state` send, exactly 1 usage event (fails pre-fix with 2/2)
- T2 window contract: in-window frame suppressed, post-window frame emits, unthrottled turn-complete snapshot still lands
- Full repo suite: 206 files / 2158 tests passed; pre-push `vp check` + typecheck clean

Model: deepseek-v4-flash via omp