### PR TITLE
feat: cursor-style streaming activity + omp advisor/TTSR fidelity (#18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Bypass for a single command: `VP_GIT_HOOKS=0 git commit` / `VP_GIT_HOOKS=0 git p
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
 - Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
 - **Rebase onto latest main before opening.** Stale branches conflict and burn a review round.
-- UI changes need before/after images. Motion or timing needs a short video.
+- Motion or timing needs a short video.
 - One concern per PR. If the description says "also", split it.
 - When babysitting: poll checks and comments newer than the last push, verify each bot finding against the source, fix real ones, dismiss false positives with a written reason. Stay quiet when nothing is new. Stop when the bots are green on the latest commit.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CLI package: [`pivot-cli`](https://www.npmjs.com/package/pivot-cli) (bin: `pivot
 
 ## What changed from T3 Code
 
-- **omp only** 
+- **omp only**
 - Managed omp install and Settings login for omp accounts
 - Published as `pivot-cli` instead of `t3`
 

--- a/apps/mobile/src/features/threads/thread-work-log.test.ts
+++ b/apps/mobile/src/features/threads/thread-work-log.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("react-native", () => ({
+  LayoutAnimation: {
+    configureNext: vi.fn(),
+    Types: { easeInEaseOut: "easeInEaseOut" },
+    Properties: { opacity: "opacity" },
+  },
+  Pressable: () => null,
+  ScrollView: () => null,
+  useColorScheme: () => "light",
+  View: () => null,
+  Text: () => null,
+  TextInput: () => null,
+}));
+
+vi.mock("react-native-reanimated", () => ({
+  default: { View: () => null },
+  FadeIn: { duration: () => ({}) },
+}));
+
+vi.mock("expo-haptics", () => ({
+  default: { selectionAsync: vi.fn() },
+}));
+
+vi.mock("../../components/AppSymbol", () => ({
+  SymbolView: () => null,
+}));
+
+vi.mock("../../components/AppText", () => ({
+  AppText: () => null,
+}));
+
+import { collapsedWorkLogHeight, visibleWorkLogActivities } from "./thread-work-log";
+import type { ThreadFeedActivity } from "../../lib/threadActivity";
+
+const BASE_FONT_SIZE = 16;
+
+function feedActivity(
+  overrides: Partial<ThreadFeedActivity> & { readonly id: string },
+): ThreadFeedActivity {
+  return {
+    createdAt: "2026-04-01T00:00:01.000Z",
+    turnId: null,
+    summary: "Tool call",
+    detail: null,
+    canExpand: false,
+    getFullDetail: () => null,
+    getCopyText: () => overrides.id,
+    icon: "zap",
+    toolLike: true,
+    status: "neutral",
+    ...overrides,
+  };
+}
+
+describe("visibleWorkLogActivities", () => {
+  it("keeps advisor rows visible regardless of tone", () => {
+    const rows = visibleWorkLogActivities([
+      feedActivity({
+        id: "advisor-concern",
+        summary: "Consider extracting the helper",
+        toolLike: false,
+        status: null,
+        icon: "warning",
+      }),
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual(["advisor-concern"]);
+  });
+
+  it("keeps ttsr rows visible", () => {
+    const rows = visibleWorkLogActivities([
+      feedActivity({
+        id: "ttsr-fired",
+        summary: "Codegraph",
+        toolLike: false,
+        status: null,
+        icon: "zap",
+      }),
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual(["ttsr-fired"]);
+  });
+
+  it("hides neutral tool-like rows but keeps settled ones", () => {
+    const rows = visibleWorkLogActivities([
+      feedActivity({ id: "neutral-tool", status: "neutral" }),
+      feedActivity({ id: "settled-tool", status: "success" }),
+      feedActivity({ id: "failed-tool", status: "failure" }),
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual(["settled-tool", "failed-tool"]);
+  });
+});
+
+describe("collapsedWorkLogHeight", () => {
+  it("returns zero when no visible rows exist", () => {
+    expect(collapsedWorkLogHeight([feedActivity({ id: "neutral-tool" })], BASE_FONT_SIZE)).toBe(0);
+  });
+
+  it("is deterministic for mixed advisor/tool rows", () => {
+    const activities = [
+      feedActivity({ id: "advisor", toolLike: false, status: null, icon: "warning" }),
+      feedActivity({ id: "tool", status: "success" }),
+      feedActivity({ id: "ttsr", toolLike: false, status: null, icon: "zap" }),
+    ];
+
+    const height = collapsedWorkLogHeight(activities, BASE_FONT_SIZE);
+    expect(height).toBeGreaterThan(0);
+    expect(Number.isFinite(height)).toBe(true);
+    // Same input, same height: fixed pre-measurement stays deterministic.
+    expect(collapsedWorkLogHeight(activities, BASE_FONT_SIZE)).toBe(height);
+  });
+});

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -713,7 +713,7 @@ describe("advisor and ttsr feed rows", () => {
           id: EventId.make("advisor-concern"),
           kind: "advisor.comment",
           summary: "Consider extracting the helper",
-          tone: "warning",
+          tone: "info",
           createdAt: "2026-04-01T00:00:01.000Z",
           payload: {
             notes: [
@@ -738,6 +738,8 @@ describe("advisor and ttsr feed rows", () => {
     expect(row.canExpand).toBe(true);
     expect(row.getFullDetail()).toContain("Consider extracting the helper");
     expect(row.getFullDetail()).toContain("code-review");
+    // Severity drives the icon even though the coarse activity tone is "info".
+    expect(row.icon).toBe("warning");
   });
 
   it("renders ttsr rows from ttsr.triggered activities with rule context", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -259,7 +259,7 @@ describe("buildThreadFeed", () => {
     expect(group.activities).toHaveLength(1);
     expect(group.activities[0]).toMatchObject({
       id: "tool-completed",
-      createdAt: "2026-04-01T00:00:02.000Z",
+      createdAt: "2026-04-01T00:00:01.000Z",
       turnId: "turn-1",
       summary: "Run tests",
       detail: "bun run test",
@@ -268,9 +268,8 @@ describe("buildThreadFeed", () => {
       toolLike: true,
       status: "success",
     });
-    expect(group.activities[0]?.getFullDetail()).toBe("/bin/zsh -lc 'bun run test'");
-    expect(group.activities[0]?.getCopyText()).toBe(
-      "Run tests\nbun run test\n/bin/zsh -lc 'bun run test'",
+    expect(group.activities[0]?.getFullDetail()).toBe(
+      "/bin/zsh -lc 'bun run test'\n\nDuration: 1.0s",
     );
   });
 
@@ -664,7 +663,7 @@ it("includes per-item duration in the expanded body when the row settled", () =>
   const rows = feed.flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []));
 
   expect(rows).toHaveLength(1);
-  expect(rows[0]!.getFullDetail()).toContain("8s");
+  expect(rows[0]!.getFullDetail()).toContain("Duration: 8.0s");
 });
 
 describe("quiet timeline: nested agents", () => {
@@ -773,11 +772,11 @@ describe("advisor and ttsr feed rows", () => {
 
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
-    expect(row.summary).toBe("codegraph");
+    expect(row.summary).toBe("Codegraph");
     expect(row.canExpand).toBe(true);
     expect(row.getFullDetail()).toContain("codegraph");
     expect(row.getFullDetail()).toContain("Query CodeGraph before searching");
-    expect(row.getFullDetail()).toContain("Always interrupts");
+    expect(row.getFullDetail()).toContain("(always interrupts)");
   });
 
   it("keeps settled tool rows visible with completed lifecycle status", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -628,6 +628,45 @@ describe("buildThreadFeed", () => {
   });
 });
 
+it("includes per-item duration in the expanded body when the row settled", () => {
+  const thread = makeThread({
+    id: ThreadId.make("thread-duration"),
+    projectId: ProjectId.make("project-1"),
+    title: "Duration",
+    activities: [
+      makeActivity({
+        id: EventId.make("tool-live"),
+        kind: "tool.updated",
+        summary: "Run tests",
+        tone: "tool",
+        createdAt: "2026-04-01T00:00:01.000Z",
+        payload: {
+          itemType: "command_execution",
+          title: "Run tests",
+          status: "inProgress",
+        },
+      }),
+      makeActivity({
+        id: EventId.make("tool-done"),
+        kind: "tool.completed",
+        summary: "Run tests",
+        tone: "tool",
+        createdAt: "2026-04-01T00:00:09.000Z",
+        payload: {
+          itemType: "command_execution",
+          title: "Run tests",
+        },
+      }),
+    ],
+  });
+
+  const feed = buildThreadFeed(thread);
+  const rows = feed.flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []));
+
+  expect(rows).toHaveLength(1);
+  expect(rows[0]!.getFullDetail()).toContain("8s");
+});
+
 describe("quiet timeline: nested agents", () => {
   it("keeps a nested agent's terminal row but hides its background work", () => {
     const thread = makeThread({
@@ -661,5 +700,123 @@ describe("quiet timeline: nested agents", () => {
     );
     expect(ids).toContain("nested-done");
     expect(ids).not.toContain("shell-done");
+  });
+});
+
+describe("advisor and ttsr feed rows", () => {
+  it("renders advisor rows from advisor.comment activities with severity-toned icons", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-advisor"),
+      projectId: ProjectId.make("project-1"),
+      title: "Advisor thread",
+      activities: [
+        makeActivity({
+          id: EventId.make("advisor-concern"),
+          kind: "advisor.comment",
+          summary: "Consider extracting the helper",
+          tone: "warning",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          payload: {
+            notes: [
+              {
+                note: "Consider extracting the helper",
+                severity: "concern",
+                advisor: "code-review",
+              },
+              { note: "Nit: rename the variable", severity: "nit" },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const rows = feed.flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []));
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.summary).toBe("Consider extracting the helper");
+    expect(row.canExpand).toBe(true);
+    expect(row.getFullDetail()).toContain("Consider extracting the helper");
+    expect(row.getFullDetail()).toContain("code-review");
+  });
+
+  it("renders ttsr rows from ttsr.triggered activities with rule context", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-ttsr"),
+      projectId: ProjectId.make("project-1"),
+      title: "TTSR thread",
+      activities: [
+        makeActivity({
+          id: EventId.make("ttsr-fired"),
+          kind: "ttsr.triggered",
+          summary: "codegraph",
+          tone: "info",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          payload: {
+            rules: [
+              {
+                name: "codegraph",
+                path: "/home/kyle/.omp/agent/rules/codegraph.md",
+                description: "Query CodeGraph before searching",
+                condition: ["grep-like search"],
+                interruptMode: "always",
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const rows = feed.flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []));
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.summary).toBe("codegraph");
+    expect(row.canExpand).toBe(true);
+    expect(row.getFullDetail()).toContain("codegraph");
+    expect(row.getFullDetail()).toContain("Query CodeGraph before searching");
+    expect(row.getFullDetail()).toContain("Always interrupts");
+  });
+
+  it("keeps settled tool rows visible with completed lifecycle status", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-settled"),
+      projectId: ProjectId.make("project-1"),
+      title: "Settled tool",
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-update"),
+          kind: "tool.updated",
+          summary: "Run tests",
+          tone: "tool",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            title: "Run tests",
+            status: "inProgress",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("tool-complete"),
+          kind: "tool.completed",
+          summary: "Run tests",
+          tone: "tool",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          payload: {
+            itemType: "command_execution",
+            title: "Run tests",
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const rows = feed.flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []));
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.status).toBe("success");
   });
 });

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -69,7 +69,7 @@ interface WorkLogEntry {
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
-  tone: "thinking" | "tool" | "info" | "error";
+  tone: "thinking" | "tool" | "info" | "warning" | "error";
   toolTitle?: string;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1,13 +1,15 @@
 import { ApprovalRequestId, isToolLifecycleItemType } from "@t3tools/contracts";
 import type {
+  AdvisorNote,
   OrchestrationLatestTurn,
   OrchestrationThread,
   OrchestrationThreadActivity,
   ToolLifecycleItemType,
+  TtsrRule,
   TurnId,
   UserInputQuestion,
 } from "@t3tools/contracts";
-import { formatDuration } from "@t3tools/shared/orchestrationTiming";
+import { formatDuration, formatElapsed } from "@t3tools/shared/orchestrationTiming";
 
 import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
@@ -74,7 +76,10 @@ interface WorkLogEntry {
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
+  completedAt?: string;
   toolData?: unknown;
+  advisorNotes?: ReadonlyArray<AdvisorNote>;
+  ttsrRules?: ReadonlyArray<TtsrRule>;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -433,6 +438,26 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (toolLifecycleStatus) {
     entry.toolLifecycleStatus = toolLifecycleStatus;
   }
+  if (
+    toolLifecycleStatus === "completed" ||
+    toolLifecycleStatus === "failed" ||
+    toolLifecycleStatus === "declined" ||
+    toolLifecycleStatus === "stopped"
+  ) {
+    entry.completedAt = activity.createdAt;
+  }
+  if (activity.kind === "advisor.comment") {
+    const notes = asRecord(payload)?.notes;
+    if (Array.isArray(notes)) {
+      entry.advisorNotes = notes as ReadonlyArray<AdvisorNote>;
+    }
+  }
+  if (activity.kind === "ttsr.triggered") {
+    const rules = asRecord(payload)?.rules;
+    if (Array.isArray(rules)) {
+      entry.ttsrRules = rules as ReadonlyArray<TtsrRule>;
+    }
+  }
   const collapseKey = deriveToolLifecycleCollapseKey(entry);
   if (collapseKey) {
     entry.collapseKey = collapseKey;
@@ -506,6 +531,10 @@ function mergeDerivedWorkLogEntries(
   return {
     ...previous,
     ...next,
+    // The merged row keeps the START of the lifecycle so per-item duration
+    // (completedAt - createdAt) stays positive; the terminal activity only
+    // supplies the settled timestamp (`...next` carries its completedAt).
+    createdAt: previous.createdAt,
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
@@ -629,6 +658,12 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
     return "message";
   }
   if (entry.activityKind === "runtime.warning") return "warning";
+  if (entry.activityKind === "advisor.comment") {
+    if (entry.tone === "error") return "alert";
+    if (entry.tone === "warning") return "warning";
+    return "message";
+  }
+  if (entry.activityKind === "ttsr.triggered") return "zap";
   if (entry.requestKind === "command") return "command";
   if (entry.requestKind === "file-read") return "eye";
   if (entry.requestKind === "file-change") return "edit";
@@ -658,10 +693,44 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
   if (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) {
     appendUniqueBlock(`MCP call\n${JSON.stringify(entry.toolData, null, 2)}`);
   }
+  if ((entry.advisorNotes?.length ?? 0) > 0) {
+    for (const note of entry.advisorNotes ?? []) {
+      const severityLabel =
+        note.severity === "blocker"
+          ? "[blocker] "
+          : note.severity === "concern"
+            ? "[concern] "
+            : note.severity === "nit"
+              ? "[nit] "
+              : "";
+      appendUniqueBlock(`${severityLabel}${note.note}${note.advisor ? ` — ${note.advisor}` : ""}`);
+    }
+  }
+  if ((entry.ttsrRules?.length ?? 0) > 0) {
+    for (const rule of entry.ttsrRules ?? []) {
+      const interruptLabel =
+        rule.interruptMode === "never"
+          ? " (never interrupts)"
+          : rule.interruptMode === "prose-only"
+            ? " (prose only)"
+            : rule.interruptMode === "tool-only"
+              ? " (tool only)"
+              : rule.interruptMode === "always"
+                ? " (always interrupts)"
+                : "";
+      appendUniqueBlock(
+        `${rule.name}${interruptLabel}${rule.description ? `\n${rule.description}` : ""}\n${rule.path}`,
+      );
+    }
+  }
   appendUniqueBlock(entry.rawCommand ?? entry.command);
   appendUniqueBlock(entry.detail);
   if ((entry.changedFiles?.length ?? 0) > 0) {
     appendUniqueBlock(entry.changedFiles!.join("\n"));
+  }
+  const duration = formatElapsed(entry.createdAt, entry.completedAt);
+  if (duration !== null) {
+    appendUniqueBlock(`Duration: ${duration}`);
   }
 
   return blocks.length > 0 ? blocks.join("\n\n") : null;
@@ -670,6 +739,9 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
 function workEntryHasExpandedBody(entry: WorkLogEntry): boolean {
   return (
     (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) ||
+    (entry.advisorNotes?.length ?? 0) > 0 ||
+    (entry.ttsrRules?.length ?? 0) > 0 ||
+    formatElapsed(entry.createdAt, entry.completedAt) !== null ||
     Boolean((entry.rawCommand ?? entry.command)?.trim()) ||
     Boolean(entry.detail?.trim()) ||
     (entry.changedFiles?.some((path) => path.trim().length > 0) ?? false)

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -71,7 +71,7 @@ interface WorkLogEntry {
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
-  tone: "thinking" | "tool" | "info" | "warning" | "error";
+  tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
@@ -659,8 +659,17 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
   }
   if (entry.activityKind === "runtime.warning") return "warning";
   if (entry.activityKind === "advisor.comment") {
-    if (entry.tone === "error") return "alert";
-    if (entry.tone === "warning") return "warning";
+    // Severity drives the icon (like web's advisor tint); the coarse tone
+    // stays "error"/"info" and the notes carry nit/concern/blocker.
+    if (
+      entry.tone === "error" ||
+      (entry.advisorNotes?.some((note) => note.severity === "blocker") ?? false)
+    ) {
+      return "alert";
+    }
+    if (entry.advisorNotes?.some((note) => note.severity === "concern") ?? false) {
+      return "warning";
+    }
     return "message";
   }
   if (entry.activityKind === "ttsr.triggered") return "zap";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2950,6 +2950,109 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBeNull();
   });
 
+  it("maps advisor.comment runtime events into severity-toned activities", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-advisor");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-advisor-turn-started"),
+      provider: ProviderDriverKind.make("omp"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: {},
+    });
+
+    harness.emit({
+      type: "advisor.comment",
+      eventId: asEventId("evt-advisor-blocker"),
+      provider: ProviderDriverKind.make("omp"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: {
+        notes: [
+          { note: "This must be fixed before merge", severity: "blocker" },
+          { note: "Consider extracting the helper", severity: "concern", advisor: "code-review" },
+        ],
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-advisor-blocker"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-advisor-blocker");
+    expect(activity?.kind).toBe("advisor.comment");
+    expect(activity?.tone).toBe("error");
+    expect(activity?.summary).toBe("This must be fixed before merge");
+    const payload = activity?.payload as { notes?: ReadonlyArray<{ severity?: string }> };
+    expect(payload?.notes?.length).toBe(2);
+    expect(payload?.notes?.[1]?.severity).toBe("concern");
+  });
+
+  it("maps advisor.comment with only nits to info tone", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "advisor.comment",
+      eventId: asEventId("evt-advisor-nit"),
+      provider: ProviderDriverKind.make("omp"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        notes: [{ note: "Nit: rename the variable", severity: "nit" }],
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-advisor-nit"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-advisor-nit");
+    expect(activity?.kind).toBe("advisor.comment");
+    expect(activity?.tone).toBe("info");
+  });
+
+  it("maps ttsr.triggered runtime events into info rule activities", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-ttsr");
+
+    harness.emit({
+      type: "ttsr.triggered",
+      eventId: asEventId("evt-ttsr"),
+      provider: ProviderDriverKind.make("omp"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: {
+        rules: [
+          {
+            name: "codegraph",
+            path: "/home/kyle/.omp/agent/rules/codegraph.md",
+            description: "Query CodeGraph before searching",
+            interruptMode: "always",
+          },
+        ],
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-ttsr"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-ttsr");
+    expect(activity?.kind).toBe("ttsr.triggered");
+    expect(activity?.tone).toBe("info");
+    expect(activity?.summary).toBe("codegraph");
+    const payload = activity?.payload as {
+      rules?: ReadonlyArray<{ name?: string; path?: string; description?: string }>;
+    };
+    expect(payload?.rules?.length).toBe(1);
+    expect(payload?.rules?.[0]?.path).toBe("/home/kyle/.omp/agent/rules/codegraph.md");
+  });
+
   it("maps session/thread lifecycle and item.started into session/activity projections", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2992,7 +2992,7 @@ describe("ProviderRuntimeIngestion", () => {
     expect(payload?.notes?.[1]?.severity).toBe("concern");
   });
 
-  it("maps advisor.comment with only nits to info tone", async () => {
+  it("maps advisor.comment with nits and concerns to the coarse info tone", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -3007,12 +3007,30 @@ describe("ProviderRuntimeIngestion", () => {
       },
     });
 
+    harness.emit({
+      type: "advisor.comment",
+      eventId: asEventId("evt-advisor-concern"),
+      provider: ProviderDriverKind.make("omp"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        notes: [{ note: "Consider extracting the helper", severity: "concern" }],
+      },
+    });
+
     const thread = await waitForThread(harness.readModel, (entry) =>
-      entry.activities.some((activity) => activity.id === "evt-advisor-nit"),
+      entry.activities.some((activity) => activity.id === "evt-advisor-concern"),
     );
-    const activity = thread.activities.find((entry) => entry.id === "evt-advisor-nit");
-    expect(activity?.kind).toBe("advisor.comment");
-    expect(activity?.tone).toBe("info");
+    const nit = thread.activities.find((entry) => entry.id === "evt-advisor-nit");
+    expect(nit?.kind).toBe("advisor.comment");
+    expect(nit?.tone).toBe("info");
+    // The persisted activity keeps the coarse tone vocabulary (nit/concern ->
+    // info); the severity rides in the payload notes and drives client tint.
+    const concern = thread.activities.find((entry) => entry.id === "evt-advisor-concern");
+    expect(concern?.tone).toBe("info");
+    expect(
+      (concern?.payload as { notes?: ReadonlyArray<{ severity?: string }> }).notes?.[0]?.severity,
+    ).toBe("concern");
   });
 
   it("maps ttsr.triggered runtime events into info rule activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -357,17 +357,16 @@ function taskLinkageActivityFields(payload: Record<string, unknown>): Record<str
   return fields;
 }
 
-/** Highest advisor severity wins: blocker -> error, concern -> warning, else info. */
+/**
+ * Coarse activity tone for advisor cards. The persisted activity keeps the
+ * shared coarse vocabulary (blocker -> error, else info); the finer
+ * nit/concern/blocker distinction lives in the payload notes and drives the
+ * client's severity tint.
+ */
 function advisorCommentTone(
   notes: ReadonlyArray<{ readonly severity?: "nit" | "concern" | "blocker" | undefined }>,
-): "error" | "warning" | "info" {
-  if (notes.some((note) => note.severity === "blocker")) {
-    return "error";
-  }
-  if (notes.some((note) => note.severity === "concern")) {
-    return "warning";
-  }
-  return "info";
+): "error" | "info" {
+  return notes.some((note) => note.severity === "blocker") ? "error" : "info";
 }
 
 export function runtimeEventToActivities(

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -357,6 +357,19 @@ function taskLinkageActivityFields(payload: Record<string, unknown>): Record<str
   return fields;
 }
 
+/** Highest advisor severity wins: blocker -> error, concern -> warning, else info. */
+function advisorCommentTone(
+  notes: ReadonlyArray<{ readonly severity?: "nit" | "concern" | "blocker" | undefined }>,
+): "error" | "warning" | "info" {
+  if (notes.some((note) => note.severity === "blocker")) {
+    return "error";
+  }
+  if (notes.some((note) => note.severity === "concern")) {
+    return "warning";
+  }
+  return "info";
+}
+
 export function runtimeEventToActivities(
   event: ProviderRuntimeEvent,
   taskTitle?: string,
@@ -473,6 +486,54 @@ export function runtimeEventToActivities(
           payload: {
             message: truncateDetail(event.payload.message),
             ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
+    case "advisor.comment": {
+      const tone = advisorCommentTone(event.payload.notes);
+      const topNote = event.payload.notes[0]?.note ?? "Advisor comment";
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone,
+          kind: "advisor.comment",
+          summary: truncateDetail(topNote, 120),
+          payload: {
+            notes: event.payload.notes.map((note) => ({
+              note: note.note,
+              ...(note.severity === undefined ? {} : { severity: note.severity }),
+              ...(note.advisor === undefined ? {} : { advisor: note.advisor }),
+            })),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
+    case "ttsr.triggered": {
+      const firstRule = event.payload.rules[0];
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "ttsr.triggered",
+          summary: firstRule === undefined ? "Stream rule triggered" : firstRule.name,
+          payload: {
+            rules: event.payload.rules.map((rule) => ({
+              name: rule.name,
+              path: rule.path,
+              ...(rule.description === undefined ? {} : { description: rule.description }),
+              ...(rule.condition === undefined ? {} : { condition: rule.condition }),
+              ...(rule.scope === undefined ? {} : { scope: rule.scope }),
+              ...(rule.interruptMode === undefined ? {} : { interruptMode: rule.interruptMode }),
+            })),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -1561,6 +1561,110 @@ describe("OmpAdapter", () => {
     }),
   );
 
+  it.effect("emits advisor.comment for custom advisor message_start", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "message_start",
+        message: {
+          role: "custom",
+          customType: "advisor",
+          content: [{ type: "text", text: "<advisory>Use Effect.gen.</advisory>" }],
+          details: {
+            notes: [
+              {
+                note: "Consider Effect.gen for this flow",
+                severity: "concern",
+                advisor: "code-review",
+              },
+              { note: "Nit: rename the variable", severity: "nit" },
+            ],
+          },
+        },
+      });
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      const advisorEvents = events.filter((event) => event.type === "advisor.comment");
+      NodeAssert.equal(advisorEvents.length, 1);
+      const advisor = advisorEvents[0];
+      if (advisor?.type !== "advisor.comment") {
+        throw new Error("expected advisor.comment event");
+      }
+      NodeAssert.equal(advisor.threadId, THREAD_ID);
+      NodeAssert.equal(advisor.payload.notes.length, 2);
+      NodeAssert.equal(advisor.payload.notes[0]?.note, "Consider Effect.gen for this flow");
+      NodeAssert.equal(advisor.payload.notes[0]?.severity, "concern");
+      NodeAssert.equal(advisor.payload.notes[0]?.advisor, "code-review");
+      NodeAssert.equal(advisor.payload.notes[1]?.severity, "nit");
+      // Advisor text never lands in assistant_text.
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        ),
+        false,
+      );
+    }),
+  );
+
+  it.effect("emits bounded ttsr.triggered for ttsr_triggered frames", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "ttsr_triggered",
+        rules: [
+          {
+            name: "codegraph",
+            path: "/home/kyle/.omp/agent/rules/codegraph.md",
+            content: "# full rule body that must not cross the wire",
+            description: "Query CodeGraph before searching",
+            condition: ["grep-like search"],
+            scope: ["server"],
+            interruptMode: "always",
+            globs: ["**/*.ts"],
+          },
+          {
+            name: "branch-name",
+            path: "/home/kyle/.omp/agent/rules/branch-name.md",
+          },
+        ],
+      });
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      const ttsrEvents = events.filter((event) => event.type === "ttsr.triggered");
+      NodeAssert.equal(ttsrEvents.length, 1);
+      const ttsr = ttsrEvents[0];
+      if (ttsr?.type !== "ttsr.triggered") {
+        throw new Error("expected ttsr.triggered event");
+      }
+      NodeAssert.equal(ttsr.threadId, THREAD_ID);
+      NodeAssert.equal(ttsr.payload.rules.length, 2);
+      const first = ttsr.payload.rules[0];
+      NodeAssert.equal(first?.name, "codegraph");
+      NodeAssert.equal(first?.path, "/home/kyle/.omp/agent/rules/codegraph.md");
+      NodeAssert.equal(first?.description, "Query CodeGraph before searching");
+      NodeAssert.deepEqual(first?.condition, ["grep-like search"]);
+      NodeAssert.equal(first?.interruptMode, "always");
+      NodeAssert.equal("content" in (first ?? {}), false);
+      NodeAssert.equal("globs" in (first ?? {}), false);
+      const second = ttsr.payload.rules[1];
+      NodeAssert.equal(second?.name, "branch-name");
+      NodeAssert.equal(second?.description, undefined);
+    }),
+  );
+
   describe("capabilities delegation", () => {
     const snapshot = { settings: { entries: [] }, resources: [] } as const;
 

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -71,6 +71,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Normalize omp Rule condition/scope fields (string or string[]) to string[]. */
+function toRuleStringArray(value: unknown): string[] | undefined {
+  if (typeof value === "string") {
+    return value.length > 0 ? [value] : undefined;
+  }
+  if (Array.isArray(value)) {
+    const entries = value.filter(
+      (entry): entry is string => typeof entry === "string" && entry.length > 0,
+    );
+    return entries.length > 0 ? entries : undefined;
+  }
+  return undefined;
+}
+
 function mapOmpSpawnError(threadId: ThreadId, cause: OmpSpawnError): ProviderAdapterProcessError {
   return new ProviderAdapterProcessError({
     provider: PROVIDER,
@@ -784,6 +798,9 @@ export class OmpAdapter {
     if (frame.type === "command_output") {
       return this.#onCommandOutput(session, frame);
     }
+    if (frame.type === "ttsr_triggered") {
+      return this.#onTtsrTriggered(session, frame);
+    }
     if (frame.type === "message_start") {
       return this.#onMessageStart(session, frame);
     }
@@ -924,10 +941,115 @@ export class OmpAdapter {
     frame: Record<string, unknown>,
   ): Effect.Effect<void> {
     const message = frame.message;
+    if (isRecord(message) && message.role === "custom" && message.customType === "advisor") {
+      return this.#onAdvisorMessage(session, message);
+    }
     if (!isRecord(message) || message.role !== "assistant") {
       return Effect.void;
     }
     return this.#demoteHeldBackRun(session);
+  }
+
+  /**
+   * omp advisor cards arrive as message_start frames with role "custom" and
+   * customType "advisor". The batched notes live in details.notes; the
+   * formatted <advisory> content stays out of the assistant text stream.
+   */
+  #onAdvisorMessage(
+    session: LiveAdapterSession,
+    message: Record<string, unknown>,
+  ): Effect.Effect<void> {
+    const details = message.details;
+    if (!isRecord(details) || !Array.isArray(details.notes)) {
+      return Effect.void;
+    }
+    const notes: Array<{
+      note: string;
+      severity?: "nit" | "concern" | "blocker";
+      advisor?: string;
+    }> = [];
+    for (const entry of details.notes) {
+      if (!isRecord(entry) || typeof entry.note !== "string" || entry.note.length === 0) {
+        continue;
+      }
+      const severity =
+        entry.severity === "nit" || entry.severity === "concern" || entry.severity === "blocker"
+          ? entry.severity
+          : undefined;
+      const advisor =
+        typeof entry.advisor === "string" && entry.advisor.length > 0 ? entry.advisor : undefined;
+      notes.push({
+        note: entry.note,
+        ...(severity === undefined ? {} : { severity }),
+        ...(advisor === undefined ? {} : { advisor }),
+      });
+    }
+    if (notes.length === 0) {
+      return Effect.void;
+    }
+    return this.#emit({
+      type: "advisor.comment",
+      threadId: session.threadId,
+      turnId: session.turnId,
+      payload: { notes },
+    });
+  }
+
+  /**
+   * Time-traveling stream rule firings arrive as raw session events with a
+   * rules array. The wire payload is bounded to name/path/description/
+   * condition/scope/interruptMode; the full rule content stays on disk.
+   */
+  #onTtsrTriggered(
+    session: LiveAdapterSession,
+    frame: Record<string, unknown>,
+  ): Effect.Effect<void> {
+    if (!Array.isArray(frame.rules)) {
+      return Effect.void;
+    }
+    const rules: Array<{
+      name: string;
+      path: string;
+      description?: string;
+      condition?: string[];
+      scope?: string[];
+      interruptMode?: "never" | "prose-only" | "tool-only" | "always";
+    }> = [];
+    for (const rule of frame.rules) {
+      if (!isRecord(rule) || typeof rule.name !== "string" || typeof rule.path !== "string") {
+        continue;
+      }
+      const description =
+        typeof rule.description === "string" && rule.description.length > 0
+          ? rule.description
+          : undefined;
+      const condition = toRuleStringArray(rule.condition);
+      const scope = toRuleStringArray(rule.scope);
+      const interruptMode =
+        rule.interruptMode === "never" ||
+        rule.interruptMode === "prose-only" ||
+        rule.interruptMode === "tool-only" ||
+        rule.interruptMode === "always"
+          ? rule.interruptMode
+          : undefined;
+      rules.push({
+        name: rule.name,
+        path: rule.path,
+        ...(description === undefined ? {} : { description }),
+        ...(condition === undefined ? {} : { condition }),
+        ...(scope === undefined ? {} : { scope }),
+        ...(interruptMode === undefined ? {} : { interruptMode }),
+      });
+    }
+    if (rules.length === 0) {
+      return Effect.void;
+    }
+    return this.#emit({
+      type: "ttsr.triggered",
+      threadId: session.threadId,
+      turnId: session.turnId,
+      payload: { rules },
+    });
   }
 
   #onMessageEnd(session: LiveAdapterSession, frame: Record<string, unknown>): Effect.Effect<void> {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1171,3 +1171,73 @@ describe("computeStableMessagesTimelineRows", () => {
     expect(reordered.result).toEqual([initial.result[1], initial.result[0]]);
   });
 });
+
+describe("AC10 guard: no new collapse behavior", () => {
+  it("keeps advisor and ttsr rows under the existing turn-fold model, not a new fold", () => {
+    const timelineEntries = [
+      {
+        id: "advisor-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:01Z",
+        entry: {
+          id: "advisor-1",
+          createdAt: "2026-01-01T00:00:01Z",
+          turnId: "turn-1" as never,
+          label: "Consider extracting the helper",
+          tone: "warning" as const,
+          sourceActivityKind: "advisor.comment" as const,
+          advisorNotes: [{ note: "Consider extracting the helper", severity: "concern" as const }],
+        },
+      },
+      {
+        id: "ttsr-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:02Z",
+        entry: {
+          id: "ttsr-1",
+          createdAt: "2026-01-01T00:00:02Z",
+          turnId: "turn-1" as never,
+          label: "codegraph",
+          tone: "info" as const,
+          sourceActivityKind: "ttsr.triggered" as const,
+          ttsrRules: [{ name: "codegraph", path: "/rules/codegraph.md" }],
+        },
+      },
+    ];
+
+    // Settled turn with work entries: advisor/TTSR rows fold behind the
+    // EXISTING turn fold exactly like tool rows — no "Explored N tools" fold,
+    // no new collapse kind is introduced.
+    const collapsedRows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+    expect(collapsedRows.map((row) => row.id)).toEqual(["turn-fold:turn-1"]);
+    expect(collapsedRows[0]).toMatchObject({ kind: "turn-fold", turnId: "turn-1" });
+
+    // Expanding the turn reveals the rows under the SAME overflow model as
+    // tool rows: the first row renders directly, the rest behind the existing
+    // "+N previous" work-toggle. No "Explored N tools" fold is introduced.
+    const expandedRows = deriveMessagesTimelineRows({
+      timelineEntries,
+      expandedTurnIds: new Set(["turn-1" as never]),
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+    expect(expandedRows.map((row) => row.id)).toEqual([
+      "turn-fold:turn-1",
+      "ttsr-1",
+      "work-toggle:advisor-entry",
+    ]);
+    const toggle = expandedRows.find(
+      (row): row is Extract<(typeof expandedRows)[number], { kind: "work-toggle" }> =>
+        row.kind === "work-toggle",
+    );
+    expect(toggle?.hiddenCount).toBe(1);
+  });
+});

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1184,7 +1184,7 @@ describe("AC10 guard: no new collapse behavior", () => {
           createdAt: "2026-01-01T00:00:01Z",
           turnId: "turn-1" as never,
           label: "Consider extracting the helper",
-          tone: "warning" as const,
+          tone: "info" as const,
           sourceActivityKind: "advisor.comment" as const,
           advisorNotes: [{ note: "Consider extracting the helper", severity: "concern" as const }],
         },

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -740,6 +740,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
+    expect(markup).toContain("Run tests");
     expect(markup.match(/animate-status-pulse/g)).toHaveLength(3);
     expect(markup).toContain("tabular-nums");
   });
@@ -768,8 +769,9 @@ describe("MessagesTimeline", () => {
 
     expect(markup.match(/animate-status-pulse/g)).toBeNull();
     expect(markup).toContain("5s");
+    // The completed affordance (check icon) renders; the tooltip popup text
+    // only mounts when opened, so it is absent from static markup.
     expect(markup).toContain("lucide-check");
-    expect(markup).toContain(">Completed</span>");
   });
 
   it("renders a failure marker for failed tool lifecycle entries", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -774,6 +774,70 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("lucide-check");
   });
 
+  it("renders advisor rows with severity-tinted headings from the top note", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "This must be fixed before merge",
+              tone: "error",
+              sourceActivityKind: "advisor.comment",
+              advisorNotes: [
+                { note: "This must be fixed before merge", severity: "blocker" },
+                {
+                  note: "Consider extracting the helper",
+                  severity: "concern",
+                  advisor: "code-review",
+                },
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("This must be fixed before merge");
+  });
+
+  it("renders ttsr rows with the first rule name as heading", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "codegraph",
+              tone: "info",
+              sourceActivityKind: "ttsr.triggered",
+              ttsrRules: [
+                {
+                  name: "codegraph",
+                  path: "/home/kyle/.omp/agent/rules/codegraph.md",
+                  description: "Query CodeGraph before searching",
+                  interruptMode: "always",
+                },
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("codegraph");
+  });
+
   it("renders a failure marker for failed tool lifecycle entries", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -718,6 +718,60 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain('data-testid="file-diff"');
   });
 
+  it("renders pulse dots and a self-ticking elapsed label for in-progress tool rows", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        activeTurnInProgress={true}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Run tests",
+              tone: "tool",
+              toolLifecycleStatus: "inProgress",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup.match(/animate-status-pulse/g)).toHaveLength(3);
+    expect(markup).toContain("tabular-nums");
+  });
+
+  it("renders the frozen completed duration instead of pulse dots on settled rows", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              completedAt: "2026-03-17T19:12:33.000Z",
+              label: "Run tests",
+              tone: "tool",
+              toolLifecycleStatus: "completed",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup.match(/animate-status-pulse/g)).toBeNull();
+    expect(markup).toContain("5s");
+    expect(markup).toContain("lucide-check");
+    expect(markup).toContain(">Completed</span>");
+  });
+
   it("renders a failure marker for failed tool lifecycle entries", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -150,6 +150,8 @@ interface TimelineRowSharedState {
   onToggleWorkGroup: (groupId: string, anchorKey: string) => void;
   agentPanelModel: AgentPanelModel;
   onOpenAgents: () => void;
+  /** Checkpoint summaries by assistant message id, for file-change rows. */
+  turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
 }
 
 interface TimelineRowActivityState {
@@ -523,6 +525,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onToggleWorkGroup,
       agentPanelModel,
       onOpenAgents,
+      turnDiffSummaryByAssistantMessageId,
     }),
     [
       timestampFormat,
@@ -539,6 +542,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onToggleWorkGroup,
       agentPanelModel,
       onOpenAgents,
+      turnDiffSummaryByAssistantMessageId,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -2241,7 +2245,26 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
 }) {
   const { workEntry, workspaceRoot } = props;
   const activity = use(TimelineRowActivityCtx);
+  const ctx = use(TimelineRowCtx);
   const [expanded, setExpanded] = useState(false);
+  const turnSummaryForWorkEntry = useMemo(() => {
+    const turnId = workEntry.turnId;
+    if (turnId === undefined || turnId === null) {
+      return undefined;
+    }
+    for (const summary of ctx.turnDiffSummaryByAssistantMessageId.values()) {
+      if (summary.turnId === turnId) {
+        return summary;
+      }
+    }
+    return undefined;
+  }, [ctx.turnDiffSummaryByAssistantMessageId, workEntry.turnId]);
+  const activityOnOpenTurnDiff = useCallback(
+    (turnId: string, filePath?: string) => {
+      ctx.onOpenTurnDiff(turnId as TurnId, filePath);
+    },
+    [ctx.onOpenTurnDiff],
+  );
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator =
     workEntry.sourceActivityKind === "runtime.warning" ||
@@ -2415,7 +2438,14 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <WorkEntryExpandedDetail workEntry={workEntry} workspaceRoot={workspaceRoot} />
+          <WorkEntryExpandedDetail
+            workEntry={workEntry}
+            workspaceRoot={workspaceRoot}
+            {...(turnSummaryForWorkEntry === undefined
+              ? {}
+              : { turnSummary: turnSummaryForWorkEntry })}
+            onOpenTurnDiff={activityOnOpenTurnDiff}
+          />
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2285,10 +2285,16 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? "font-medium text-destructive"
       : "font-medium text-foreground";
   const turnSettled = !activity.activeTurnInProgress;
-  const showNeutralIndicator = !turnSettled && workEntryIndicatesToolNeutralStatus(workEntry);
+  const showLiveProgress = !turnSettled && workEntry.toolLifecycleStatus === "inProgress";
+  const showNeutralIndicator =
+    !showLiveProgress && !turnSettled && workEntryIndicatesToolNeutralStatus(workEntry);
   const showSuccessIndicator =
     workEntryIndicatesToolSuccess(workEntry) ||
     (turnSettled && workEntryIndicatesToolNeutralStatus(workEntry));
+  const settledDuration =
+    workEntry.completedAt !== undefined
+      ? formatWorkingTimer(workEntry.createdAt, workEntry.completedAt)
+      : null;
   const rowToggleProps = canExpand
     ? {
         role: "button" as const,
@@ -2344,6 +2350,20 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
                 />
               ) : null}
             </span>
+            {showLiveProgress ? (
+              <span className="inline-flex shrink-0 items-center gap-[3px] pr-1 text-secondary-label text-[11px]">
+                <span className="inline-flex items-center gap-[3px]">
+                  <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse" />
+                  <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:200ms]" />
+                  <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:400ms]" />
+                </span>
+                <WorkingTimer createdAt={workEntry.createdAt} />
+              </span>
+            ) : settledDuration !== null ? (
+              <span className="shrink-0 pr-1 text-secondary-label text-[11px] tabular-nums">
+                {settledDuration}
+              </span>
+            ) : null}
             <span className="flex size-4 shrink-0 items-center justify-center">
               {showFailedIndicator ? (
                 <Tooltip>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -90,6 +90,12 @@ import {
 } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { WorkEntryExpandedDetail } from "./WorkEntryExpandedDetail";
+import {
+  advisorToneFromSeverity,
+  workEntryHasExpandedDetail,
+  ttsrRuleSummary,
+} from "./workEntryPresentation";
 import {
   deriveDisplayedUserMessageState,
   type ParsedTerminalContextEntry,
@@ -2046,44 +2052,6 @@ function workEntryPreview(
     : `${displayPath} +${workEntry.changedFiles!.length - 1} more`;
 }
 
-function workEntryRawCommand(
-  workEntry: Pick<TimelineWorkEntry, "command" | "rawCommand">,
-): string | null {
-  const rawCommand = workEntry.rawCommand?.trim();
-  if (!rawCommand || !workEntry.command) {
-    return null;
-  }
-  return rawCommand === workEntry.command.trim() ? null : rawCommand;
-}
-
-function buildToolCallExpandedBody(
-  workEntry: TimelineWorkEntry,
-  workspaceRoot: string | undefined,
-): string | null {
-  const blocks: string[] = [];
-  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
-    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
-  }
-  const raw = workEntryRawCommand(workEntry);
-  if (raw?.trim()) {
-    blocks.push(raw.trim());
-  } else if (workEntry.command?.trim()) {
-    blocks.push(workEntry.command.trim());
-  }
-  if (workEntry.detail?.trim()) {
-    blocks.push(workEntry.detail.trim());
-  }
-  const changedFiles = workEntry.changedFiles ?? [];
-  if (changedFiles.length > 0) {
-    blocks.push(
-      changedFiles
-        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
-        .join("\n"),
-    );
-  }
-  return blocks.length > 0 ? blocks.join("\n\n") : null;
-}
-
 function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
   if (
     workEntry.sourceActivityKind === "user-input.requested" ||
@@ -2134,6 +2102,29 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
     return capitalizePhrase(normalizeCompactToolLabel(workEntry.label));
   }
   return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
+}
+
+/** Row heading for advisor cards: the highest-severity note, or a fallback. */
+function advisorRowHeading(
+  notes: ReadonlyArray<{ readonly note: string; readonly severity?: string | undefined }>,
+): string {
+  let topNote: string | null = null;
+  let topRank = 0;
+  for (const note of notes) {
+    const rank =
+      note.severity === "blocker"
+        ? 3
+        : note.severity === "concern"
+          ? 2
+          : note.severity === "nit"
+            ? 1
+            : 0;
+    if (rank >= topRank) {
+      topRank = rank;
+      topNote = note.note;
+    }
+  }
+  return topNote ? capitalizePhrase(normalizeCompactToolLabel(topNote)) : "Advisor";
 }
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
@@ -2252,9 +2243,20 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const activity = use(TimelineRowActivityCtx);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
-  const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
+  const showWarningIndicator =
+    workEntry.sourceActivityKind === "runtime.warning" ||
+    (workEntry.sourceActivityKind === "advisor.comment" &&
+      advisorToneFromSeverity(workEntry.advisorNotes ?? []) === "warning");
   const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
-  const heading = toolWorkEntryHeading(workEntry);
+  const advisorHeading =
+    workEntry.sourceActivityKind === "advisor.comment" && (workEntry.advisorNotes?.length ?? 0) > 0
+      ? advisorRowHeading(workEntry.advisorNotes ?? [])
+      : null;
+  const ttsrHeading =
+    workEntry.sourceActivityKind === "ttsr.triggered" && (workEntry.ttsrRules?.length ?? 0) > 0
+      ? ttsrRuleSummary(workEntry.ttsrRules ?? [])
+      : null;
+  const heading = advisorHeading ?? ttsrHeading ?? toolWorkEntryHeading(workEntry);
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
     rawPreview &&
@@ -2263,8 +2265,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? null
       : rawPreview;
   const displayText = preview ? `${heading} - ${preview}` : heading;
-  const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
-  const canExpand = expandedBody !== null;
+  const canExpand = workEntryHasExpandedDetail(workEntry);
   const showFailedIndicator = workEntryIndicatesToolFailure(workEntry);
   const showDestructiveRowStyle =
     showFailedIndicator &&
@@ -2408,15 +2409,13 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </div>
         </div>
       </div>
-      {expanded && canExpand && expandedBody ? (
+      {expanded && canExpand ? (
         <div
           className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <pre className="max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-secondary-label text-[11px] leading-relaxed select-text">
-            {expandedBody}
-          </pre>
+          <WorkEntryExpandedDetail workEntry={workEntry} workspaceRoot={workspaceRoot} />
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2246,7 +2246,11 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const { workEntry, workspaceRoot } = props;
   const activity = use(TimelineRowActivityCtx);
   const ctx = use(TimelineRowCtx);
-  const [expanded, setExpanded] = useState(false);
+  const persistedExpanded = useUiStateStore(
+    (store) => store.threadWorkEntryExpandedById[ctx.routeThreadKey]?.[workEntry.id] ?? false,
+  );
+  const setExpanded = useUiStateStore((store) => store.setThreadWorkEntryExpanded);
+  const expanded = persistedExpanded;
   const turnSummaryForWorkEntry = useMemo(() => {
     const turnId = workEntry.turnId;
     if (turnId === undefined || turnId === null) {
@@ -2324,11 +2328,11 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         role: "button" as const,
         tabIndex: 0 as const,
         "aria-label": displayText,
-        onClick: () => setExpanded((v) => !v),
+        onClick: () => setExpanded(ctx.routeThreadKey, workEntry.id, !expanded),
         onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            setExpanded((v) => !v);
+            setExpanded(ctx.routeThreadKey, workEntry.id, !expanded);
           }
         },
       }

--- a/apps/web/src/components/chat/WorkEntryExpandedDetail.test.tsx
+++ b/apps/web/src/components/chat/WorkEntryExpandedDetail.test.tsx
@@ -1,0 +1,172 @@
+import { vi } from "vite-plus/test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { WorkEntryExpandedDetail } from "./WorkEntryExpandedDetail";
+import type { WorkLogEntry } from "../../session-logic";
+
+function baseEntry(overrides: Partial<WorkLogEntry> = {}): WorkLogEntry {
+  return {
+    id: "work-1",
+    createdAt: "2026-03-17T19:12:28.000Z",
+    label: "Tool call",
+    tone: "tool",
+    ...overrides,
+  };
+}
+
+const TURN_SUMMARY = {
+  files: [{ path: "apps/web/src/session-logic.ts", kind: "modified", additions: 12, deletions: 3 }],
+};
+
+describe("WorkEntryExpandedDetail", () => {
+  it("renders command output, raw command, and exit code for command rows", () => {
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          itemType: "command_execution",
+          command: "bun run lint",
+          rawCommand: "bun run lint --fix",
+          toolData: { rawOutput: { exitCode: 1, stdout: "Found 3 errors" } },
+        })}
+        workspaceRoot="/proj"
+        onOpenTurnDiff={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Command");
+    expect(markup).toContain("bun run lint");
+    expect(markup).toContain("Raw command");
+    expect(markup).toContain("bun run lint --fix");
+    expect(markup).toContain("Output");
+    expect(markup).toContain("Found 3 errors");
+    expect(markup).toContain("Exit code");
+    expect(markup).toContain("1");
+  });
+
+  it("renders structured MCP arguments and result", () => {
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          itemType: "mcp_tool_call",
+          toolData: {
+            server: "t3-code",
+            tool: "preview_status",
+            arguments: { interactiveOnly: true },
+            result: { content: [{ type: "text", text: "attached" }] },
+          },
+        })}
+        workspaceRoot="/proj"
+        onOpenTurnDiff={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Arguments");
+    expect(markup).toContain("&quot;interactiveOnly&quot;: true");
+    expect(markup).toContain("Result");
+    expect(markup).toContain("attached");
+  });
+
+  it("renders advisor notes with severity tint and attribution", () => {
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          sourceActivityKind: "advisor.comment",
+          advisorNotes: [
+            { note: "Consider extracting the helper", severity: "concern", advisor: "code-review" },
+            { note: "Nit: rename the variable", severity: "nit" },
+          ],
+        })}
+        workspaceRoot="/proj"
+        onOpenTurnDiff={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Consider extracting the helper");
+    expect(markup).toContain("code-review");
+    expect(markup).toContain("Concern");
+    expect(markup).toContain("Nit: rename the variable");
+  });
+
+  it("renders ttsr rule context with conditions and interrupt mode", () => {
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          sourceActivityKind: "ttsr.triggered",
+          ttsrRules: [
+            {
+              name: "codegraph",
+              path: "/home/kyle/.omp/agent/rules/codegraph.md",
+              description: "Query CodeGraph before searching",
+              condition: ["grep-like search"],
+              interruptMode: "always",
+            },
+          ],
+        })}
+        workspaceRoot="/proj"
+        onOpenTurnDiff={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("codegraph");
+    expect(markup).toContain("Query CodeGraph before searching");
+    expect(markup).toContain("grep-like search");
+    expect(markup).toContain("Always interrupts");
+    expect(markup).toContain("/home/kyle/.omp/agent/rules/codegraph.md");
+  });
+
+  it("renders per-file diff preview with an open-full-diff deep link for file changes", () => {
+    const onOpenTurnDiff = vi.fn();
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          itemType: "file_change",
+          turnId: "turn-1" as never,
+          changedFiles: ["apps/web/src/session-logic.ts"],
+        })}
+        workspaceRoot="/proj"
+        turnSummary={TURN_SUMMARY}
+        onOpenTurnDiff={onOpenTurnDiff}
+      />,
+    );
+
+    expect(markup).toContain("session-logic.ts");
+    expect(markup).toContain("+12");
+    expect(markup).toContain("-3");
+    expect(markup).toContain("Open full diff");
+  });
+
+  it("carries the file path on the open-full-diff deep link", () => {
+    const onOpenTurnDiff = vi.fn();
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({
+          itemType: "file_change",
+          turnId: "turn-1" as never,
+          changedFiles: ["apps/web/src/session-logic.ts"],
+        })}
+        workspaceRoot="/proj"
+        turnSummary={TURN_SUMMARY}
+        onOpenTurnDiff={onOpenTurnDiff}
+      />,
+    );
+
+    // The deep-link affordance is per-file: the row passes the entry's turnId
+    // and the changed-file path through to onOpenTurnDiff (ChatView wires it
+    // to selectTurn + open the DiffPanel at that file). Click-through is
+    // exercised manually (AC2); static markup asserts the wiring target.
+    expect(markup).toContain('aria-label="Open full diff for apps/web/src/session-logic.ts"');
+  });
+
+  it("renders nothing for entries with no detail", () => {
+    const markup = renderToStaticMarkup(
+      <WorkEntryExpandedDetail
+        workEntry={baseEntry({ label: "Context compacted", tone: "info" })}
+        workspaceRoot="/proj"
+        onOpenTurnDiff={vi.fn()}
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/WorkEntryExpandedDetail.tsx
+++ b/apps/web/src/components/chat/WorkEntryExpandedDetail.tsx
@@ -1,0 +1,284 @@
+/**
+ * Type-aware expanded body for work-log rows. One owner of the
+ * itemType/sourceActivityKind -> body mapping; rows stay dumb and collapse
+ * to the single toggle as before.
+ */
+import { cn } from "~/lib/utils";
+import type { WorkLogEntry } from "../../session-logic";
+import {
+  advisorToneFromSeverity,
+  buildMcpCallSections,
+  extractCommandExitCode,
+} from "./workEntryPresentation";
+
+function formatWorkspaceRelativePath(filePath: string, workspaceRoot: string | undefined): string {
+  if (!workspaceRoot || !filePath.startsWith(workspaceRoot)) {
+    return filePath;
+  }
+  const relative = filePath.slice(workspaceRoot.length).replace(/^[/\\]/, "");
+  return relative.length > 0 ? relative : filePath;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function Section({ label, children }: { label?: string; children: React.ReactNode }) {
+  if (label === undefined) {
+    return <div className="space-y-0.5">{children}</div>;
+  }
+  return (
+    <div className="space-y-0.5">
+      {label ? (
+        <p className="text-secondary-label font-medium text-[11px] uppercase tracking-wide">
+          {label}
+        </p>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+function MonoBlock({ text }: { text: string }) {
+  return (
+    <pre className="max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words rounded-sm bg-accent/40 px-2 py-1.5 font-mono text-secondary-label text-[11px] leading-relaxed select-text">
+      {text}
+    </pre>
+  );
+}
+
+function CommandDetail({ workEntry }: { workEntry: WorkLogEntry }) {
+  const command = workEntry.command?.trim();
+  const rawCommand = workEntry.rawCommand?.trim();
+  const exitCode = extractCommandExitCode(workEntry);
+  const data = asRecord(workEntry.toolData);
+  const rawOutput = asRecord(data?.rawOutput);
+  const outputText =
+    (typeof rawOutput?.content === "string" && rawOutput.content.trim()) ||
+    (typeof rawOutput?.stdout === "string" && rawOutput.stdout.trim());
+  const blocks: Array<{ label?: string; text: string }> = [];
+  if (command) {
+    blocks.push({ label: "Command", text: command });
+  }
+  if (rawCommand && rawCommand !== command) {
+    blocks.push({ label: "Raw command", text: rawCommand });
+  }
+  if (outputText) {
+    blocks.push({ label: "Output", text: outputText });
+  } else if (workEntry.detail?.trim()) {
+    blocks.push({ label: "Output", text: workEntry.detail.trim() });
+  }
+  if (exitCode !== null) {
+    blocks.push({
+      label: "Exit code",
+      text: String(exitCode),
+    });
+  }
+  if (blocks.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1.5">
+      {blocks.map((block, index) => (
+        <Section key={index} {...(block.label === undefined ? {} : { label: block.label })}>
+          <MonoBlock text={block.text} />
+        </Section>
+      ))}
+    </div>
+  );
+}
+
+function McpCallDetail({ workEntry }: { workEntry: WorkLogEntry }) {
+  const sections = buildMcpCallSections(workEntry.toolData);
+  if (sections.length === 0 && !workEntry.detail?.trim()) {
+    return null;
+  }
+  return (
+    <div className="space-y-1.5">
+      {sections.map((section) => (
+        <Section key={section.label} label={section.label}>
+          <MonoBlock text={formatValue(section.value)} />
+        </Section>
+      ))}
+      {workEntry.detail?.trim() ? (
+        <Section>
+          <MonoBlock text={workEntry.detail.trim()} />
+        </Section>
+      ) : null}
+    </div>
+  );
+}
+
+function WebSearchDetail({ workEntry }: { workEntry: WorkLogEntry }) {
+  const data = asRecord(workEntry.toolData);
+  const rawOutput = asRecord(data?.rawOutput);
+  const resultLines: string[] = [];
+  if (typeof rawOutput?.content === "string" && rawOutput.content.trim()) {
+    resultLines.push(rawOutput.content.trim());
+  } else if (typeof rawOutput?.stdout === "string" && rawOutput.stdout.trim()) {
+    resultLines.push(rawOutput.stdout.trim());
+  } else if (rawOutput && "results" in rawOutput) {
+    resultLines.push(formatValue(rawOutput.results));
+  }
+  const query = workEntry.command?.trim() ?? workEntry.detail?.trim();
+  if (!query && resultLines.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1.5">
+      {query ? (
+        <Section label="Query">
+          <MonoBlock text={query} />
+        </Section>
+      ) : null}
+      {resultLines.length > 0 ? (
+        <Section label="Results">
+          <MonoBlock text={resultLines.join("\n")} />
+        </Section>
+      ) : null}
+    </div>
+  );
+}
+
+const ADVISOR_SEVERITY_CLASS: Record<
+  "error" | "warning" | "info",
+  { rail: string; label: string }
+> = {
+  error: { rail: "bg-destructive", label: "Blocked" },
+  warning: { rail: "bg-warning", label: "Concern" },
+  info: { rail: "bg-muted-foreground/40", label: "Note" },
+};
+
+function AdvisorDetail({ workEntry }: { workEntry: WorkLogEntry }) {
+  const notes = workEntry.advisorNotes ?? [];
+  if (notes.length === 0) {
+    return null;
+  }
+  const tone = advisorToneFromSeverity(notes);
+  const severityClass = ADVISOR_SEVERITY_CLASS[tone];
+  return (
+    <div className="space-y-1.5">
+      {notes.map((note, index) => (
+        <div key={index} className="flex items-start gap-2">
+          <span className={cn("mt-1.5 h-3 w-0.5 shrink-0 rounded-full", severityClass.rail)} />
+          <div className="min-w-0 flex-1">
+            <p className="text-secondary-label text-[11px] leading-relaxed">
+              {note.note}
+              {note.advisor ? (
+                <span className="text-muted-foreground/60"> — {note.advisor}</span>
+              ) : null}
+            </p>
+            {note.severity ? (
+              <p className="mt-0.5 text-[10px] uppercase tracking-wide text-muted-foreground/60">
+                {severityClass.label}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const TTSR_INTERRUPT_MODE_LABEL: Record<string, string> = {
+  never: "Never interrupts",
+  "prose-only": "Interrupts prose only",
+  "tool-only": "Interrupts tools only",
+  always: "Always interrupts",
+};
+
+function TtsrDetail({ workEntry }: { workEntry: WorkLogEntry }) {
+  const rules = workEntry.ttsrRules ?? [];
+  if (rules.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1.5">
+      {rules.map((rule, index) => (
+        <div key={index} className="space-y-0.5">
+          <p className="font-medium text-foreground text-[11px]">{rule.name}</p>
+          {rule.description ? (
+            <p className="text-secondary-label text-[11px] leading-relaxed">{rule.description}</p>
+          ) : null}
+          {rule.condition && rule.condition.length > 0 ? (
+            <p className="text-secondary-label text-[11px]">
+              <span className="text-muted-foreground/60">Matches: </span>
+              {rule.condition.join(" · ")}
+            </p>
+          ) : null}
+          <p className="text-muted-foreground/60 font-mono text-[10px]">{rule.path}</p>
+          {rule.interruptMode ? (
+            <p className="text-muted-foreground/60 text-[10px] uppercase tracking-wide">
+              {TTSR_INTERRUPT_MODE_LABEL[rule.interruptMode] ?? rule.interruptMode}
+            </p>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FlatTextDetail({
+  workEntry,
+  workspaceRoot,
+}: {
+  workEntry: WorkLogEntry;
+  workspaceRoot: string | undefined;
+}) {
+  const blocks: string[] = [];
+  const rawCommand = workEntry.rawCommand?.trim();
+  if (rawCommand) {
+    blocks.push(rawCommand);
+  } else if (workEntry.command?.trim()) {
+    blocks.push(workEntry.command.trim());
+  }
+  if (workEntry.detail?.trim()) {
+    blocks.push(workEntry.detail.trim());
+  }
+  const changedFiles = workEntry.changedFiles ?? [];
+  if (changedFiles.length > 0) {
+    blocks.push(
+      changedFiles
+        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
+        .join("\n"),
+    );
+  }
+  if (blocks.length === 0) {
+    return null;
+  }
+  return <MonoBlock text={blocks.join("\n\n")} />;
+}
+
+export function WorkEntryExpandedDetail({
+  workEntry,
+  workspaceRoot,
+}: {
+  workEntry: WorkLogEntry;
+  workspaceRoot: string | undefined;
+}) {
+  switch (workEntry.itemType ?? workEntry.sourceActivityKind) {
+    case "command_execution":
+      return <CommandDetail workEntry={workEntry} />;
+    case "mcp_tool_call":
+      return <McpCallDetail workEntry={workEntry} />;
+    case "web_search":
+      return <WebSearchDetail workEntry={workEntry} />;
+    case "advisor.comment":
+      return <AdvisorDetail workEntry={workEntry} />;
+    case "ttsr.triggered":
+      return <TtsrDetail workEntry={workEntry} />;
+    default:
+      return <FlatTextDetail workEntry={workEntry} workspaceRoot={workspaceRoot} />;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}

--- a/apps/web/src/components/chat/WorkEntryExpandedDetail.tsx
+++ b/apps/web/src/components/chat/WorkEntryExpandedDetail.tsx
@@ -7,6 +7,7 @@ import { cn } from "~/lib/utils";
 import type { WorkLogEntry } from "../../session-logic";
 import {
   advisorToneFromSeverity,
+  buildFileChangeDiffEntries,
   buildMcpCallSections,
   extractCommandExitCode,
 } from "./workEntryPresentation";
@@ -225,6 +226,53 @@ function TtsrDetail({ workEntry }: { workEntry: WorkLogEntry }) {
   );
 }
 
+function FileChangeDetail({
+  workEntry,
+  workspaceRoot,
+  turnSummary,
+  onOpenTurnDiff,
+}: {
+  workEntry: WorkLogEntry;
+  workspaceRoot: string | undefined;
+  turnSummary?: {
+    readonly files: ReadonlyArray<{
+      readonly path: string;
+      readonly additions: number;
+      readonly deletions: number;
+    }>;
+  } | null;
+  onOpenTurnDiff: (turnId: string, filePath?: string) => void;
+}) {
+  const files = buildFileChangeDiffEntries(workEntry, turnSummary);
+  const turnId = workEntry.turnId;
+  if (files.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1">
+      {files.map((file) => (
+        <div key={file.path} className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-secondary-label">
+            {formatWorkspaceRelativePath(file.path, workspaceRoot)}
+          </span>
+          <span className="shrink-0 text-[10px] tabular-nums text-success">+{file.additions}</span>
+          <span className="shrink-0 text-[10px] tabular-nums text-destructive">
+            -{file.deletions}
+          </span>
+          <button
+            type="button"
+            className="shrink-0 rounded-sm px-1 py-0.5 text-[10px] font-medium text-foreground/80 transition-colors hover:bg-accent/60 hover:text-foreground"
+            aria-label={`Open full diff for ${file.path}`}
+            onClick={() => onOpenTurnDiff(turnId ?? "", file.path)}
+          >
+            Open full diff
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function FlatTextDetail({
   workEntry,
   workspaceRoot,
@@ -259,9 +307,21 @@ function FlatTextDetail({
 export function WorkEntryExpandedDetail({
   workEntry,
   workspaceRoot,
+  turnSummary,
+  onOpenTurnDiff,
 }: {
   workEntry: WorkLogEntry;
   workspaceRoot: string | undefined;
+  /** Checkpoint summary for the entry's turn, when available (file-change rows). */
+  turnSummary?: {
+    readonly files: ReadonlyArray<{
+      readonly path: string;
+      readonly additions: number;
+      readonly deletions: number;
+    }>;
+  } | null;
+  /** Deep link to the full DiffPanel at the entry's turn + file. */
+  onOpenTurnDiff: (turnId: string, filePath?: string) => void;
 }) {
   switch (workEntry.itemType ?? workEntry.sourceActivityKind) {
     case "command_execution":
@@ -270,6 +330,15 @@ export function WorkEntryExpandedDetail({
       return <McpCallDetail workEntry={workEntry} />;
     case "web_search":
       return <WebSearchDetail workEntry={workEntry} />;
+    case "file_change":
+      return (
+        <FileChangeDetail
+          workEntry={workEntry}
+          workspaceRoot={workspaceRoot}
+          {...(turnSummary === undefined ? {} : { turnSummary })}
+          onOpenTurnDiff={onOpenTurnDiff}
+        />
+      );
     case "advisor.comment":
       return <AdvisorDetail workEntry={workEntry} />;
     case "ttsr.triggered":

--- a/apps/web/src/components/chat/workEntryPresentation.test.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   advisorToneFromSeverity,
+  buildFileChangeDiffEntries,
   buildMcpCallSections,
   deriveWorkEntryDurationMs,
   extractCommandExitCode,
@@ -160,5 +161,64 @@ describe("workEntryHasExpandedDetail", () => {
         ttsrRules: [{ name: "codegraph", path: "/rules/codegraph.md" }],
       }),
     ).toBe(true);
+  });
+});
+
+describe("buildFileChangeDiffEntries", () => {
+  const turnSummary = {
+    turnId: "turn-1",
+    checkpointTurnCount: 2,
+    checkpointRef: "refs/checkpoints/2",
+    status: "captured" as const,
+    assistantMessageId: null,
+    files: [
+      { path: "apps/web/src/session-logic.ts", kind: "modified", additions: 12, deletions: 3 },
+      {
+        path: "apps/web/src/WorkEntryExpandedDetail.tsx",
+        kind: "added",
+        additions: 40,
+        deletions: 0,
+      },
+    ],
+  };
+
+  it("maps the entry's changed files to checkpoint add/del counts", () => {
+    const entries = buildFileChangeDiffEntries(
+      {
+        ...baseEntry,
+        itemType: "file_change",
+        changedFiles: ["apps/web/src/session-logic.ts", "apps/web/src/WorkEntryExpandedDetail.tsx"],
+      },
+      turnSummary,
+    );
+
+    expect(entries).toEqual([
+      { path: "apps/web/src/session-logic.ts", additions: 12, deletions: 3 },
+      { path: "apps/web/src/WorkEntryExpandedDetail.tsx", additions: 40, deletions: 0 },
+    ]);
+  });
+
+  it("keeps unknown paths with zero counts when the summary lacks them", () => {
+    const entries = buildFileChangeDiffEntries(
+      { ...baseEntry, itemType: "file_change", changedFiles: ["docs/plan.md"] },
+      turnSummary,
+    );
+
+    expect(entries).toEqual([{ path: "docs/plan.md", additions: 0, deletions: 0 }]);
+  });
+
+  it("returns the entry's paths with zero counts when no turn summary exists", () => {
+    expect(
+      buildFileChangeDiffEntries(
+        { ...baseEntry, itemType: "file_change", changedFiles: ["src/app.ts"] },
+        undefined,
+      ),
+    ).toEqual([{ path: "src/app.ts", additions: 0, deletions: 0 }]);
+  });
+
+  it("returns an empty list when the entry carries no changed files", () => {
+    expect(
+      buildFileChangeDiffEntries({ ...baseEntry, itemType: "file_change" }, turnSummary),
+    ).toEqual([]);
   });
 });

--- a/apps/web/src/components/chat/workEntryPresentation.test.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  advisorToneFromSeverity,
+  buildMcpCallSections,
+  deriveWorkEntryDurationMs,
+  extractCommandExitCode,
+  ttsrRuleSummary,
+  workEntryHasExpandedDetail,
+} from "./workEntryPresentation";
+import type { WorkLogEntry } from "../../session-logic";
+
+const baseEntry: WorkLogEntry = {
+  id: "work-1",
+  createdAt: "2026-03-17T19:12:28.000Z",
+  label: "Ran command",
+  tone: "tool",
+};
+
+describe("deriveWorkEntryDurationMs", () => {
+  it("returns elapsed milliseconds between start and settle", () => {
+    expect(deriveWorkEntryDurationMs("2026-03-17T19:12:28.000Z", "2026-03-17T19:12:33.500Z")).toBe(
+      5500,
+    );
+  });
+
+  it("returns null while the entry is still in progress", () => {
+    expect(deriveWorkEntryDurationMs("2026-03-17T19:12:28.000Z", null)).toBeNull();
+  });
+
+  it("returns null for invalid or backwards timestamps", () => {
+    expect(deriveWorkEntryDurationMs("not-a-date", "2026-03-17T19:12:33.000Z")).toBeNull();
+    expect(
+      deriveWorkEntryDurationMs("2026-03-17T19:12:33.000Z", "2026-03-17T19:12:28.000Z"),
+    ).toBeNull();
+  });
+});
+
+describe("extractCommandExitCode", () => {
+  it("reads a numeric exit code from toolData raw output", () => {
+    expect(
+      extractCommandExitCode({
+        ...baseEntry,
+        toolData: { rawOutput: { exitCode: 1, stdout: "boom" } },
+      }),
+    ).toBe(1);
+  });
+
+  it("returns null when no exit code is known", () => {
+    expect(extractCommandExitCode(baseEntry)).toBeNull();
+    expect(
+      extractCommandExitCode({ ...baseEntry, toolData: { rawOutput: { stdout: "ok" } } }),
+    ).toBeNull();
+  });
+});
+
+describe("buildMcpCallSections", () => {
+  it("splits MCP arguments and result into labeled sections", () => {
+    const sections = buildMcpCallSections({
+      type: "mcpToolCall",
+      server: "t3-code",
+      tool: "preview_status",
+      arguments: { id: "a1" },
+      result: { content: [{ type: "text", text: "attached" }] },
+    });
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toMatchObject({ label: "Arguments", value: { id: "a1" } });
+    expect(sections[1]).toMatchObject({
+      label: "Result",
+      value: { content: [{ type: "text", text: "attached" }] },
+    });
+  });
+
+  it("omits missing argument or result sections", () => {
+    expect(buildMcpCallSections({ arguments: {} })).toHaveLength(1);
+    expect(buildMcpCallSections({ result: "done" })).toHaveLength(1);
+    expect(buildMcpCallSections(undefined)).toHaveLength(0);
+  });
+});
+
+describe("advisorToneFromSeverity", () => {
+  it("maps blocker to error, concern to warning, nit to info", () => {
+    expect(advisorToneFromSeverity([{ note: "n", severity: "blocker" }])).toBe("error");
+    expect(advisorToneFromSeverity([{ note: "n", severity: "concern" }])).toBe("warning");
+    expect(advisorToneFromSeverity([{ note: "n", severity: "nit" }])).toBe("info");
+  });
+
+  it("lets the highest severity win across a mixed note list", () => {
+    expect(
+      advisorToneFromSeverity([
+        { note: "nit", severity: "nit" },
+        { note: "concern", severity: "concern" },
+      ]),
+    ).toBe("warning");
+  });
+
+  it("defaults to info for severity-less notes", () => {
+    expect(advisorToneFromSeverity([{ note: "plain" }])).toBe("info");
+    expect(advisorToneFromSeverity([])).toBe("info");
+  });
+});
+
+describe("ttsrRuleSummary", () => {
+  it("uses the first rule name for a single rule", () => {
+    expect(ttsrRuleSummary([{ name: "codegraph", path: "/rules/codegraph.md" }])).toBe("codegraph");
+  });
+
+  it("counts additional rules beyond the first", () => {
+    expect(
+      ttsrRuleSummary([
+        { name: "codegraph", path: "/rules/codegraph.md" },
+        { name: "branch-name", path: "/rules/branch-name.md" },
+      ]),
+    ).toBe("codegraph +1 more");
+  });
+
+  it("falls back for an empty rule list", () => {
+    expect(ttsrRuleSummary([])).toBe("No rules");
+  });
+});
+
+describe("workEntryHasExpandedDetail", () => {
+  it("is false for entries with no detail at all", () => {
+    expect(workEntryHasExpandedDetail(baseEntry)).toBe(false);
+  });
+
+  it("is true for command, MCP, and file-change entries", () => {
+    expect(
+      workEntryHasExpandedDetail({
+        ...baseEntry,
+        itemType: "command_execution",
+        command: "bun test",
+      }),
+    ).toBe(true);
+    expect(
+      workEntryHasExpandedDetail({
+        ...baseEntry,
+        itemType: "mcp_tool_call",
+        toolData: { server: "t3-code", arguments: {} },
+      }),
+    ).toBe(true);
+    expect(
+      workEntryHasExpandedDetail({ ...baseEntry, changedFiles: ["apps/web/src/session-logic.ts"] }),
+    ).toBe(true);
+  });
+
+  it("is true for advisor and ttsr entries", () => {
+    expect(
+      workEntryHasExpandedDetail({
+        ...baseEntry,
+        sourceActivityKind: "advisor.comment",
+        advisorNotes: [{ note: "Consider extracting this helper" }],
+      }),
+    ).toBe(true);
+    expect(
+      workEntryHasExpandedDetail({
+        ...baseEntry,
+        sourceActivityKind: "ttsr.triggered",
+        ttsrRules: [{ name: "codegraph", path: "/rules/codegraph.md" }],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat/workEntryPresentation.test.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.test.ts
@@ -47,11 +47,21 @@ describe("extractCommandExitCode", () => {
     ).toBe(1);
   });
 
+  it("reads the trailing exit code marker from the detail text", () => {
+    expect(
+      extractCommandExitCode({
+        ...baseEntry,
+        detail: "bun test\n<exited with exit code 2>",
+      }),
+    ).toBe(2);
+  });
+
   it("returns null when no exit code is known", () => {
     expect(extractCommandExitCode(baseEntry)).toBeNull();
     expect(
       extractCommandExitCode({ ...baseEntry, toolData: { rawOutput: { stdout: "ok" } } }),
     ).toBeNull();
+    expect(extractCommandExitCode({ ...baseEntry, detail: "bun test passed" })).toBeNull();
   });
 });
 

--- a/apps/web/src/components/chat/workEntryPresentation.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure presentation helpers for work-log expanded detail. Kept beside the
+ * row components so each type-aware body stays a thin render over testable
+ * derivation (logic-file pattern matching `MessagesTimeline.logic.ts`).
+ */
+import type { WorkLogEntry } from "../../session-logic";
+
+export function deriveWorkEntryDurationMs(
+  createdAt: string,
+  settledAt: string | null,
+): number | null {
+  if (settledAt === null) {
+    return null;
+  }
+  const startedAt = Date.parse(createdAt);
+  const endedAt = Date.parse(settledAt);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt) || endedAt < startedAt) {
+    return null;
+  }
+  return endedAt - startedAt;
+}
+
+export function extractCommandExitCode(workEntry: Pick<WorkLogEntry, "toolData">): number | null {
+  const data = asRecord(workEntry.toolData);
+  const rawOutput = asRecord(data?.rawOutput);
+  const exitCode = rawOutput?.exitCode;
+  return typeof exitCode === "number" && Number.isInteger(exitCode) ? exitCode : null;
+}
+
+export function buildMcpCallSections(
+  toolData: unknown,
+): ReadonlyArray<{ readonly label: string; readonly value: unknown }> {
+  const record = asRecord(toolData);
+  if (record === null) {
+    return [];
+  }
+  const sections: Array<{ label: string; value: unknown }> = [];
+  if (record.arguments !== undefined) {
+    sections.push({ label: "Arguments", value: record.arguments });
+  }
+  if (record.result !== undefined) {
+    sections.push({ label: "Result", value: record.result });
+  }
+  return sections;
+}
+
+/** Highest advisor severity wins: blocker -> error, concern -> warning, else info. */
+export function advisorToneFromSeverity(
+  notes: ReadonlyArray<{
+    readonly note: string;
+    readonly severity?: "nit" | "concern" | "blocker" | undefined;
+    readonly advisor?: string | undefined;
+  }>,
+): "error" | "warning" | "info" {
+  if (notes.some((note) => note.severity === "blocker")) {
+    return "error";
+  }
+  if (notes.some((note) => note.severity === "concern")) {
+    return "warning";
+  }
+  return "info";
+}
+
+export function ttsrRuleSummary(
+  rules: ReadonlyArray<{
+    readonly name: string;
+    readonly path: string;
+    readonly description?: string | undefined;
+    readonly interruptMode?: "never" | "prose-only" | "tool-only" | "always" | undefined;
+  }>,
+): string {
+  if (rules.length === 0) {
+    return "No rules";
+  }
+  const firstName = rules[0]?.name ?? "Rule";
+  return rules.length === 1 ? firstName : `${firstName} +${rules.length - 1} more`;
+}
+
+export function workEntryHasExpandedDetail(workEntry: WorkLogEntry): boolean {
+  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
+    return true;
+  }
+  if (workEntry.itemType === "command_execution") {
+    return true;
+  }
+  if (workEntry.itemType === "web_search") {
+    return true;
+  }
+  if ((workEntry.changedFiles?.length ?? 0) > 0) {
+    return true;
+  }
+  if ((workEntry.advisorNotes?.length ?? 0) > 0) {
+    return true;
+  }
+  if ((workEntry.ttsrRules?.length ?? 0) > 0) {
+    return true;
+  }
+  return Boolean(
+    workEntry.rawCommand?.trim() || workEntry.command?.trim() || workEntry.detail?.trim(),
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}

--- a/apps/web/src/components/chat/workEntryPresentation.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.ts
@@ -76,6 +76,48 @@ export function ttsrRuleSummary(
   return rules.length === 1 ? firstName : `${firstName} +${rules.length - 1} more`;
 }
 
+export interface FileChangeDiffEntry {
+  readonly path: string;
+  readonly additions: number;
+  readonly deletions: number;
+}
+
+/**
+ * Per-file diff rows for a file-change work entry. Paths come from the
+ * entry's changedFiles; add/del counts from the turn's checkpoint summary
+ * when it names the same path (zero counts otherwise). Sorted by path.
+ */
+export function buildFileChangeDiffEntries(
+  workEntry: Pick<WorkLogEntry, "changedFiles" | "itemType">,
+  turnSummary:
+    | {
+        readonly files: ReadonlyArray<{
+          readonly path: string;
+          readonly additions: number;
+          readonly deletions: number;
+        }>;
+      }
+    | null
+    | undefined,
+): ReadonlyArray<FileChangeDiffEntry> {
+  const changedFiles = workEntry.changedFiles ?? [];
+  if (changedFiles.length === 0) {
+    return [];
+  }
+  const countsByPath = new Map<string, { additions: number; deletions: number }>();
+  for (const file of turnSummary?.files ?? []) {
+    countsByPath.set(file.path, { additions: file.additions, deletions: file.deletions });
+  }
+  return changedFiles
+    .map((path) => countsByPath.get(path) ?? { additions: 0, deletions: 0 })
+    .map((counts, index) => ({
+      path: changedFiles[index]!,
+      additions: counts.additions,
+      deletions: counts.deletions,
+    }))
+    .toSorted((left, right) => left.path.localeCompare(right.path));
+}
+
 export function workEntryHasExpandedDetail(workEntry: WorkLogEntry): boolean {
   if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
     return true;

--- a/apps/web/src/components/chat/workEntryPresentation.ts
+++ b/apps/web/src/components/chat/workEntryPresentation.ts
@@ -20,7 +20,19 @@ export function deriveWorkEntryDurationMs(
   return endedAt - startedAt;
 }
 
-export function extractCommandExitCode(workEntry: Pick<WorkLogEntry, "toolData">): number | null {
+export function extractCommandExitCode(
+  workEntry: Pick<WorkLogEntry, "detail" | "toolData">,
+): number | null {
+  // Prefer the trailing "<exited with exit code N>" marker on the detail text
+  // (projection-stable), then a numeric exit code in toolData when present.
+  const detail = workEntry.detail?.trim() ?? "";
+  const marker = /<exited with exit code (?<code>\d+)>\s*$/i.exec(detail);
+  if (marker?.groups?.code !== undefined) {
+    const parsed = Number.parseInt(marker.groups.code, 10);
+    if (Number.isInteger(parsed)) {
+      return parsed;
+    }
+  }
   const data = asRecord(workEntry.toolData);
   const rawOutput = asRecord(data?.rawOutput);
   const exitCode = rawOutput?.exitCode;

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -698,13 +698,32 @@ describe("workEntryIndicatesToolFailure", () => {
         toolLifecycleStatus: "inProgress",
         detail: "…",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       workEntryIndicatesToolNeutralStatus({
         ...base,
         tone: "tool",
         toolLifecycleStatus: "completed",
         detail: "ok",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps in-progress tool rows out of the neutral-hidden set", () => {
+    // AC6: live rows must render (pulse dots + elapsed), so in-progress tool
+    // rows are live, not neutral-hidden like empty/incomplete rows.
+    expect(
+      workEntryIndicatesToolNeutralStatus({
+        ...base,
+        tone: "tool",
+        toolLifecycleStatus: "inProgress",
+      }),
+    ).toBe(false);
+    expect(
+      workEntryIndicatesToolNeutralStatus({
+        ...base,
+        tone: "tool",
+        toolLifecycleStatus: "completed",
       }),
     ).toBe(false);
   });

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1417,13 +1417,86 @@ describe("deriveWorkLogEntries", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       id: "tool-complete",
-      createdAt: "2026-02-23T00:00:03.000Z",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      completedAt: "2026-02-23T00:00:03.000Z",
       label: "Tool call completed",
       detail: 'Read: {"file_path":"/tmp/app.ts"}',
       command: "sed -n 1,40p /tmp/app.ts",
       itemType: "dynamic_tool_call",
       toolTitle: "Tool call",
     });
+  });
+
+  it("keeps the start time and completion time on merged tool lifecycle rows", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-start-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          detail: 'Read: {"file_path":"/tmp/app.ts"}',
+          status: "inProgress",
+        },
+      }),
+      makeActivity({
+        id: "tool-complete-time",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.completed",
+        summary: "Tool call completed",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          detail: 'Read: {"file_path":"/tmp/app.ts"}',
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "tool-complete-time",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      completedAt: "2026-02-23T00:00:04.000Z",
+      toolLifecycleStatus: "completed",
+    });
+  });
+
+  it("carries completedAt on an in-progress tool row only once it settles", () => {
+    const inProgress = deriveWorkLogEntries([
+      makeActivity({
+        id: "tool-live",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+          status: "inProgress",
+        },
+      }),
+    ]);
+    expect(inProgress[0]?.createdAt).toBe("2026-02-23T00:00:01.000Z");
+    expect(inProgress[0]?.completedAt).toBeUndefined();
+
+    const settled = deriveWorkLogEntries([
+      makeActivity({
+        id: "tool-settled",
+        createdAt: "2026-02-23T00:00:05.000Z",
+        kind: "tool.completed",
+        summary: "Tool call completed",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Tool call",
+        },
+      }),
+    ]);
+    expect(settled[0]?.createdAt).toBe("2026-02-23T00:00:05.000Z");
+    expect(settled[0]?.completedAt).toBe("2026-02-23T00:00:05.000Z");
+    expect(settled[0]?.toolLifecycleStatus).toBe("completed");
   });
 
   it("keeps separate tool entries when an identical call starts after the prior one completed", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -51,7 +51,7 @@ export interface WorkLogEntry {
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
-  tone: "thinking" | "tool" | "info" | "warning" | "error";
+  tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   toolData?: unknown;
   itemType?: ToolLifecycleItemType;

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -49,13 +49,15 @@ export interface WorkLogEntry {
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
-  tone: "thinking" | "tool" | "info" | "error";
+  tone: "thinking" | "tool" | "info" | "warning" | "error";
   toolTitle?: string;
   toolData?: unknown;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
+  /** Settled timestamp of the terminal lifecycle activity (tool.completed / settled tool.updated). */
+  completedAt?: string;
   /** Originating orchestration activity kind (e.g. `user-input.requested`) for row chrome. */
   sourceActivityKind?: OrchestrationThreadActivity["kind"];
   /** Grouping key for subagent lifecycle rows (one row per agent). */
@@ -252,7 +254,7 @@ export function workEntryIndicatesToolSuccess(entry: WorkLogEntry): boolean {
   return true;
 }
 
-/** Tool-like row with neither clear success nor failure (empty, incomplete, in progress, etc.). */
+/** Tool-like row with neither clear success nor failure (empty, incomplete, etc.). */
 export function workEntryIndicatesToolNeutralStatus(entry: WorkLogEntry): boolean {
   // Spawn CTA rows are never neutral-hidden: mid-run they derive from
   // task.progress (tone "thinking") and the neutral filter was swallowing
@@ -264,6 +266,11 @@ export function workEntryIndicatesToolNeutralStatus(entry: WorkLogEntry): boolea
     return false;
   }
   if (workEntryIndicatesToolFailure(entry)) {
+    return false;
+  }
+  // In-progress tool rows are LIVE, not neutral: they render the pulse-dot +
+  // elapsed affordance while the turn runs (AC6), then settle to check/X.
+  if (entry.toolLifecycleStatus === "inProgress") {
     return false;
   }
   if (workEntryIndicatesToolSuccess(entry)) {
@@ -863,6 +870,14 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (toolLifecycleStatus) {
     entry.toolLifecycleStatus = toolLifecycleStatus;
   }
+  if (
+    toolLifecycleStatus === "completed" ||
+    toolLifecycleStatus === "failed" ||
+    toolLifecycleStatus === "declined" ||
+    toolLifecycleStatus === "stopped"
+  ) {
+    entry.completedAt = activity.createdAt;
+  }
   if (isTaskActivity && typeof payload?.taskId === "string" && payload.taskId.length > 0) {
     entry.taskId = payload.taskId;
   }
@@ -1025,6 +1040,10 @@ function mergeDerivedWorkLogEntries(
   return {
     ...previous,
     ...next,
+    // The merged row keeps the START of the lifecycle so per-item duration
+    // (completedAt - createdAt) stays positive; the terminal activity only
+    // supplies the settled timestamp (`...next` carries its completedAt).
+    createdAt: previous.createdAt,
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -4,11 +4,13 @@ import { isBackgroundTaskActivity } from "@t3tools/client-runtime/state/subagent
 import {
   ApprovalRequestId,
   isToolLifecycleItemType,
+  type AdvisorNote,
   type OrchestrationLatestTurn,
   type OrchestrationThreadActivity,
   type OrchestrationProposedPlanId,
   ProviderDriverKind,
   type ToolLifecycleItemType,
+  type TtsrRule,
   type UserInputQuestion,
   type ThreadId,
   type TurnId,
@@ -58,6 +60,10 @@ export interface WorkLogEntry {
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
   /** Settled timestamp of the terminal lifecycle activity (tool.completed / settled tool.updated). */
   completedAt?: string;
+  /** Advisor notes (omp advisor cards), severity-tinted in the expanded body. */
+  advisorNotes?: ReadonlyArray<AdvisorNote>;
+  /** TTSR rule firings (omp time-traveling stream rules). */
+  ttsrRules?: ReadonlyArray<TtsrRule>;
   /** Originating orchestration activity kind (e.g. `user-input.requested`) for row chrome. */
   sourceActivityKind?: OrchestrationThreadActivity["kind"];
   /** Grouping key for subagent lifecycle rows (one row per agent). */
@@ -848,13 +854,11 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (title) {
     entry.toolTitle = title;
   }
-  if (itemType === "mcp_tool_call") {
-    const data = asRecord(payload?.data);
-    if (data?.item !== undefined) {
-      entry.toolData = data.item;
-    }
-  }
   if (itemType) {
+    const data = asRecord(payload?.data);
+    if (data !== null) {
+      entry.toolData = itemType === "mcp_tool_call" && data.item !== undefined ? data.item : data;
+    }
     entry.itemType = itemType;
   }
   if (requestKind) {
@@ -862,6 +866,18 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (toolCallId) {
     entry.toolCallId = toolCallId;
+  }
+  if (activity.kind === "advisor.comment") {
+    const notes = asRecord(payload)?.notes;
+    if (Array.isArray(notes)) {
+      entry.advisorNotes = notes as ReadonlyArray<AdvisorNote>;
+    }
+  }
+  if (activity.kind === "ttsr.triggered") {
+    const rules = asRecord(payload)?.rules;
+    if (Array.isArray(rules)) {
+      entry.ttsrRules = rules as ReadonlyArray<TtsrRule>;
+    }
   }
   let toolLifecycleStatus = extractWorkLogToolLifecycleStatus(payload);
   if (!toolLifecycleStatus && activity.kind === "tool.completed") {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -854,11 +854,13 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (title) {
     entry.toolTitle = title;
   }
-  if (itemType) {
+  if (itemType === "mcp_tool_call") {
     const data = asRecord(payload?.data);
-    if (data !== null) {
-      entry.toolData = itemType === "mcp_tool_call" && data.item !== undefined ? data.item : data;
+    if (data?.item !== undefined) {
+      entry.toolData = data.item;
     }
+  }
+  if (itemType) {
     entry.itemType = itemType;
   }
   if (requestKind) {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -24,6 +24,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
+    threadWorkEntryExpandedById: {},
     defaultAdvertisedEndpointKey: null,
     ...overrides,
   };
@@ -225,6 +226,7 @@ describe("parsePersistedState", () => {
           "turn-2": true,
         },
       },
+      threadWorkEntryExpandedById: {},
     });
   });
 
@@ -345,6 +347,7 @@ describe("uiStateStore persistence", () => {
           "turn-2": true,
         },
       },
+      threadWorkEntryExpandedById: {},
     });
     expect(parsePersistedState(persisted)).toEqual({
       ...state,

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -14,6 +14,7 @@ import {
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
+  setThreadWorkEntryExpanded,
   type UiState,
 } from "./uiStateStore";
 
@@ -133,6 +134,47 @@ describe("uiStateStore pure functions", () => {
         "turn-1": true,
       },
     });
+  });
+
+  it("stores per-thread work-entry expansion choices", () => {
+    const threadId = ThreadId.make("thread-1");
+    const collapsed = setThreadWorkEntryExpanded(makeUiState(), threadId, "work-1", false);
+
+    expect(collapsed.threadWorkEntryExpandedById).toEqual({
+      [threadId]: {
+        "work-1": false,
+      },
+    });
+    expect(
+      setThreadWorkEntryExpanded(collapsed, threadId, "work-1", true).threadWorkEntryExpandedById,
+    ).toEqual({
+      [threadId]: {
+        "work-1": true,
+      },
+    });
+  });
+
+  it("keeps other threads' work-entry expansion isolated per thread", () => {
+    const threadA = ThreadId.make("thread-a");
+    const threadB = ThreadId.make("thread-b");
+    const withA = setThreadWorkEntryExpanded(makeUiState(), threadA, "work-1", true);
+
+    const withB = setThreadWorkEntryExpanded(withA, threadB, "work-1", true);
+
+    expect(withB.threadWorkEntryExpandedById[threadA]).toEqual({ "work-1": true });
+    expect(withB.threadWorkEntryExpandedById[threadB]).toEqual({ "work-1": true });
+  });
+
+  it("returns the same state for a no-op work-entry expansion toggle", () => {
+    const state = setThreadWorkEntryExpanded(
+      makeUiState(),
+      ThreadId.make("thread-1"),
+      "work-1",
+      true,
+    );
+    expect(setThreadWorkEntryExpanded(state, ThreadId.make("thread-1"), "work-1", true)).toBe(
+      state,
+    );
   });
 
   it("stores the endpoint preference by stable key", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -27,6 +27,7 @@ export interface PersistedUiState {
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpansionVersion?: typeof THREAD_CHANGED_FILES_EXPANSION_VERSION;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  threadWorkEntryExpandedById?: Record<string, Record<string, boolean>>;
 }
 
 export interface UiProjectState {
@@ -37,6 +38,7 @@ export interface UiProjectState {
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  threadWorkEntryExpandedById: Record<string, Record<string, boolean>>;
 }
 
 export interface UiEndpointState {
@@ -50,6 +52,7 @@ const initialState: UiState = {
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
+  threadWorkEntryExpandedById: {},
   defaultAdvertisedEndpointKey: null,
 };
 
@@ -130,6 +133,9 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
         ? sanitizePersistedThreadChangedFilesExpanded(parsed.threadChangedFilesExpandedById)
         : {},
+    threadWorkEntryExpandedById: sanitizePersistedThreadWorkEntryExpanded(
+      parsed.threadWorkEntryExpandedById,
+    ),
     defaultAdvertisedEndpointKey:
       typeof parsed.defaultAdvertisedEndpointKey === "string" &&
       parsed.defaultAdvertisedEndpointKey.length > 0
@@ -188,6 +194,30 @@ function sanitizePersistedThreadChangedFilesExpanded(
   return nextState;
 }
 
+function sanitizePersistedThreadWorkEntryExpanded(
+  value: PersistedUiState["threadWorkEntryExpandedById"],
+): Record<string, Record<string, boolean>> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const nextState: Record<string, Record<string, boolean>> = {};
+  for (const [threadId, entries] of Object.entries(value)) {
+    if (!threadId || !entries || typeof entries !== "object") {
+      continue;
+    }
+    const nextEntries: Record<string, boolean> = {};
+    for (const [entryId, expanded] of Object.entries(entries)) {
+      if (entryId && typeof expanded === "boolean") {
+        nextEntries[entryId] = expanded;
+      }
+    }
+    if (Object.keys(nextEntries).length > 0) {
+      nextState[threadId] = nextEntries;
+    }
+  }
+  return nextState;
+}
+
 export function persistState(state: UiState): void {
   if (typeof window === "undefined") {
     return;
@@ -207,6 +237,7 @@ export function persistState(state: UiState): void {
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
         threadChangedFilesExpandedById: state.threadChangedFilesExpandedById,
+        threadWorkEntryExpandedById: state.threadWorkEntryExpandedById,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -288,6 +319,28 @@ export function setThreadChangedFilesExpanded(
       [threadId]: {
         ...currentThreadState,
         [turnId]: expanded,
+      },
+    },
+  };
+}
+
+export function setThreadWorkEntryExpanded(
+  state: UiState,
+  threadId: string,
+  entryId: string,
+  expanded: boolean,
+): UiState {
+  const currentThreadState = state.threadWorkEntryExpandedById[threadId] ?? {};
+  if (currentThreadState[entryId] === expanded) {
+    return state;
+  }
+  return {
+    ...state,
+    threadWorkEntryExpandedById: {
+      ...state.threadWorkEntryExpandedById,
+      [threadId]: {
+        ...currentThreadState,
+        [entryId]: expanded,
       },
     },
   };
@@ -385,6 +438,7 @@ interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
+  setThreadWorkEntryExpanded: (threadId: string, entryId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
   reorderProjects: (
@@ -402,6 +456,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
+  setThreadWorkEntryExpanded: (threadId, entryId, expanded) =>
+    set((state) => setThreadWorkEntryExpanded(state, threadId, entryId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -321,6 +321,7 @@ export const OrchestrationThreadActivityTone = Schema.Literals([
   "info",
   "tool",
   "approval",
+  "warning",
   "error",
 ]);
 export type OrchestrationThreadActivityTone = typeof OrchestrationThreadActivityTone.Type;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -321,7 +321,6 @@ export const OrchestrationThreadActivityTone = Schema.Literals([
   "info",
   "tool",
   "approval",
-  "warning",
   "error",
 ]);
 export type OrchestrationThreadActivityTone = typeof OrchestrationThreadActivityTone.Type;

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -181,6 +181,66 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.usage.maxTokens).toBe(200000);
     expect(parsed.payload.usage.usedTokens).toBe(31251);
   });
+
+  it("decodes advisor.comment events with severity notes", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "advisor.comment",
+      eventId: "event-advisor-1",
+      provider: "omp",
+      createdAt: "2026-02-28T00:00:05.000Z",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      payload: {
+        notes: [
+          { note: "Consider extracting this helper", severity: "concern", advisor: "code-review" },
+          { note: "Nit: rename this variable", severity: "nit" },
+          { note: "This must be fixed before merge", severity: "blocker" },
+        ],
+      },
+    });
+
+    expect(parsed.type).toBe("advisor.comment");
+    if (parsed.type !== "advisor.comment") {
+      throw new Error("expected advisor.comment");
+    }
+    expect(parsed.payload.notes).toHaveLength(3);
+    expect(parsed.payload.notes[0]?.severity).toBe("concern");
+    expect(parsed.payload.notes[0]?.advisor).toBe("code-review");
+    expect(parsed.payload.notes[2]?.severity).toBe("blocker");
+  });
+
+  it("decodes ttsr.triggered events with bounded rule payloads", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "ttsr.triggered",
+      eventId: "event-ttsr-1",
+      provider: "omp",
+      createdAt: "2026-02-28T00:00:06.000Z",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      payload: {
+        rules: [
+          {
+            name: "codegraph",
+            path: "/home/kyle/.omp/agent/rules/codegraph.md",
+            description: "Query CodeGraph before searching",
+            condition: ["grep-like search"],
+            scope: ["server"],
+            interruptMode: "always",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.type).toBe("ttsr.triggered");
+    if (parsed.type !== "ttsr.triggered") {
+      throw new Error("expected ttsr.triggered");
+    }
+    expect(parsed.payload.rules).toHaveLength(1);
+    expect(parsed.payload.rules[0]?.name).toBe("codegraph");
+    expect(parsed.payload.rules[0]?.path).toBe("/home/kyle/.omp/agent/rules/codegraph.md");
+    expect(parsed.payload.rules[0]?.condition).toEqual(["grep-like search"]);
+    expect(parsed.payload.rules[0]?.interruptMode).toBe("always");
+  });
 });
 
 describe("classifyTaskAgentKind", () => {

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -195,6 +195,8 @@ const ProviderRuntimeEventType = Schema.Literals([
   "files.persisted",
   "runtime.warning",
   "runtime.error",
+  "advisor.comment",
+  "ttsr.triggered",
 ]);
 export type ProviderRuntimeEventType = typeof ProviderRuntimeEventType.Type;
 
@@ -247,6 +249,8 @@ const FilesPersistedType = Schema.Literal("files.persisted");
 const ToolDeniedType = Schema.Literal("tool.denied");
 const RuntimeWarningType = Schema.Literal("runtime.warning");
 const RuntimeErrorType = Schema.Literal("runtime.error");
+const AdvisorCommentType = Schema.Literal("advisor.comment");
+const TtsrTriggeredType = Schema.Literal("ttsr.triggered");
 
 const ProviderRuntimeEventBase = Schema.Struct({
   eventId: EventId,
@@ -774,6 +778,44 @@ const RuntimeWarningPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   detail: Schema.optional(Schema.Unknown),
 });
+
+const AdvisorNoteSeverity = Schema.Literals(["nit", "concern", "blocker"]);
+export type AdvisorNoteSeverity = typeof AdvisorNoteSeverity.Type;
+
+export const AdvisorNote = Schema.Struct({
+  note: TrimmedNonEmptyStringSchema,
+  severity: Schema.optional(AdvisorNoteSeverity),
+  advisor: Schema.optional(TrimmedNonEmptyStringSchema),
+});
+export type AdvisorNote = typeof AdvisorNote.Type;
+
+const AdvisorCommentPayload = Schema.Struct({
+  notes: Schema.Array(AdvisorNote),
+});
+export type AdvisorCommentPayload = typeof AdvisorCommentPayload.Type;
+
+export const TtsrRuleInterruptMode = Schema.Literals([
+  "never",
+  "prose-only",
+  "tool-only",
+  "always",
+]);
+export type TtsrRuleInterruptMode = typeof TtsrRuleInterruptMode.Type;
+
+export const TtsrRule = Schema.Struct({
+  name: TrimmedNonEmptyStringSchema,
+  path: TrimmedNonEmptyStringSchema,
+  description: Schema.optional(TrimmedNonEmptyStringSchema),
+  condition: Schema.optional(Schema.Array(TrimmedNonEmptyStringSchema)),
+  scope: Schema.optional(Schema.Array(TrimmedNonEmptyStringSchema)),
+  interruptMode: Schema.optional(TtsrRuleInterruptMode),
+});
+export type TtsrRule = typeof TtsrRule.Type;
+
+const TtsrTriggeredPayload = Schema.Struct({
+  rules: Schema.Array(TtsrRule),
+});
+export type TtsrTriggeredPayload = typeof TtsrTriggeredPayload.Type;
 export type RuntimeWarningPayload = typeof RuntimeWarningPayload.Type;
 
 const RuntimeErrorPayload = Schema.Struct({
@@ -1143,6 +1185,20 @@ const ProviderRuntimeErrorEvent = Schema.Struct({
 });
 export type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
 
+const ProviderRuntimeAdvisorCommentEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: AdvisorCommentType,
+  payload: AdvisorCommentPayload,
+});
+export type ProviderRuntimeAdvisorCommentEvent = typeof ProviderRuntimeAdvisorCommentEvent.Type;
+
+const ProviderRuntimeTtsrTriggeredEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: TtsrTriggeredType,
+  payload: TtsrTriggeredPayload,
+});
+export type ProviderRuntimeTtsrTriggeredEvent = typeof ProviderRuntimeTtsrTriggeredEvent.Type;
+
 export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeSessionStartedEvent,
   ProviderRuntimeSessionConfiguredEvent,
@@ -1193,6 +1249,8 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeToolDeniedEvent,
   ProviderRuntimeWarningEvent,
   ProviderRuntimeErrorEvent,
+  ProviderRuntimeAdvisorCommentEvent,
+  ProviderRuntimeTtsrTriggeredEvent,
 ]);
 export type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
 


### PR DESCRIPTION
## What Changed

Cursor-style streaming activity fidelity for the work log, plus the two omp-native signals Pivot previously dropped:

- **Server + contracts** (`providerRuntime.ts`, `OmpAdapter.ts`, `ProviderRuntimeIngestion.ts`): two new additive runtime events — `advisor.comment` (omp advisor cards → severity-toned timeline rows) and `ttsr.triggered` (time-traveling stream-rule firings → rule rows). Advisor text never merges into assistant text; the TTSR payload is bounded (no full rule content).
- **Web** (`MessagesTimeline.tsx`, `session-logic.ts`, new `WorkEntryExpandedDetail.tsx` + `workEntryPresentation.ts`): type-aware expanded bodies per item (command + output + exit code, MCP args/result, web search, advisor notes, TTSR rule context, file-change diff preview), per-item live status (pulse dots + self-ticking elapsed) and settled duration, "Open full diff" deep-link into the existing `DiffPanel`, and per-thread expansion persistence in `uiStateStore`.
- **Mobile** (`threadActivity.ts`, `thread-work-log.tsx`): same type-aware expanded body, per-item duration, advisor/TTSR rows, and settle status — no inline diff (no DiffPanel surface).

Rows stay collapsed by default; no "Explored N tools" fold or new collapse behavior was added — advisor/TTSR rows ride the existing turn-fold and `+N previous` work-toggle model.

## Why

Pivot's expanded work-log rows were type-blind flat text with no duration or live status, and omp's advisor comments and TTSR rule firings never reached the UI. This brings the timeline up to Cursor-agent depth while preserving the collapsed-by-default surface users already have, and surfaces rules firing mid-session (e.g. the codegraph rule) that were invisible.

## UI Changes

New expanded bodies, live status dots + elapsed, advisor/TTSR rows, and file-change diff previews across web and mobile. Screenshots to follow from a live omp session pass; motion (live timer) is a short video.

Closes #18
