### PR TITLE
feat(web): edit omp settings with type-aware controls and JSON modals

### DIFF
--- a/apps/server/src/provider/omp/OmpCapabilitiesService.test.ts
+++ b/apps/server/src/provider/omp/OmpCapabilitiesService.test.ts
@@ -39,9 +39,18 @@ const LIST_JSON = {
   "power.sleepPrevention": { value: "idle", type: "enum", description: "" },
 };
 
+/** Human `omp config list` output; enum entries carry choices in the type column. */
+const HUMAN_LIST = [
+  "  theme.dark = titanium (string)",
+  "  auth.broker.token = ******** (string)",
+  "  advisor.enabled = true (boolean)",
+  "  power.sleepPrevention = idle (off|idle|display|system)",
+].join("\n");
+
 function makeRunner(options: {
   readonly agentDir: string;
   readonly listJson?: Record<string, unknown>;
+  readonly humanList?: string;
 }) {
   const calls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
   const runner = ProcessRunner.ProcessRunner.of({
@@ -54,6 +63,9 @@ function makeRunner(options: {
         }
         if (key === `${OMP} config list --json`) {
           return emptyProcessOutput({ stdout: encodeJsonString(options.listJson ?? LIST_JSON) });
+        }
+        if (key === `${OMP} config list`) {
+          return emptyProcessOutput({ stdout: options.humanList ?? HUMAN_LIST });
         }
         if (input.args[0] === "config") {
           // set/reset succeed by default
@@ -155,6 +167,21 @@ it.layer(NodeServices.layer)("OmpCapabilitiesService", (it) => {
     }),
   );
 
+  it.effect("attaches enum choices parsed from the human config list", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const agentDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-omp-agent-" });
+      const { runner } = makeRunner({ agentDir });
+      const service = yield* makeService({ agentDir, runner });
+
+      const snapshot = yield* service.getSnapshot();
+      const sleep = snapshot.settings.entries.find((e) => e.key === "power.sleepPrevention");
+      expect(sleep?.values).toEqual(["off", "idle", "display", "system"]);
+      const theme = snapshot.settings.entries.find((e) => e.key === "theme.dark");
+      expect(theme?.values).toBeUndefined();
+    }),
+  );
+
   it.effect("exposes the settings surface from omp config list --json with masked secrets", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -189,6 +216,23 @@ it.layer(NodeServices.layer)("OmpCapabilitiesService", (it) => {
       expect(snapshot.settings.entries.length).toBeGreaterThan(0);
       const setCall = calls.find((c) => c.args[0] === "config" && c.args[1] === "set");
       expect(setCall?.args).toEqual(["config", "set", "theme.dark", "midnight"]);
+    }),
+  );
+
+  it.effect("serializes structured global values as JSON for omp config set", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const agentDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-omp-agent-" });
+      const { runner, calls } = makeRunner({ agentDir });
+      const service = yield* makeService({ agentDir, runner });
+
+      yield* service.writeSetting({
+        key: "modelRoles",
+        value: { default: "openai/gpt-5" },
+        scope: "global",
+      });
+      const setCall = calls.find((c) => c.args[0] === "config" && c.args[1] === "set");
+      expect(setCall?.args).toEqual(["config", "set", "modelRoles", '{"default":"openai/gpt-5"}']);
     }),
   );
 

--- a/apps/server/src/provider/omp/OmpCapabilitiesService.ts
+++ b/apps/server/src/provider/omp/OmpCapabilitiesService.ts
@@ -47,6 +47,13 @@ import { OmpConfigStore } from "./OmpConfigStore.ts";
 
 const MASKED_VALUE = "********";
 
+/**
+ * Schema-based JSON encoder (the repo lint forbids bare JSON.stringify).
+ * Used to serialize structured setting values for `omp config set`, whose
+ * CLI parses records/arrays back out of JSON.
+ */
+const encodeUnknownJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+
 /** Setting keys whose values are credentials → masked on the surface (D6). */
 const SECRET_KEY_PATTERN = /(token|secret|password|api)/i;
 
@@ -76,12 +83,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isSecretSetting = (key: string, type: string): boolean =>
   type === "secret" || SECRET_KEY_PATTERN.test(key);
 
-/**
- * Extract the `description` from a leading YAML frontmatter block, leniently:
- * only the first `---`-delimited block is inspected and only the first
- * `description:` line is used. Missing or malformed frontmatter yields
- * `undefined` (display-only; never fails the snapshot).
- */
 function parseFrontmatterDescription(content: string): string | undefined {
   if (!content.startsWith("---")) return undefined;
   const end = content.indexOf("\n---");
@@ -159,7 +160,13 @@ export class OmpCapabilitiesService {
         });
       }
       if (input.scope === "global") {
-        yield* this.runOmpConfig(["set", input.key, String(input.value)]);
+        // `omp config set` parses values schema-driven (booleans, numbers,
+        // JSON arrays/records) from a single string argument. String()
+        // alone would serialize records/arrays as "[object Object]" and
+        // corrupt the config, so only primitives pass through verbatim.
+        const serialized =
+          typeof input.value === "string" ? input.value : encodeUnknownJson(input.value);
+        yield* this.runOmpConfig(["set", input.key, serialized]);
       } else {
         const projectCwd = yield* this.resolveProjectScopeCwd(input.projectId);
         yield* this.backup(projectCwd);
@@ -320,16 +327,19 @@ export class OmpCapabilitiesService {
           reason: "omp config list --json returned an unexpected shape",
         });
       }
+      const enumValues = yield* this.readEnumValues();
       const entries: OmpSettingsSurfaceEntry[] = [];
       for (const [key, info] of Object.entries(raw)) {
         if (!isRecord(info) || typeof info.type !== "string") {
           continue;
         }
         const masked = isSecretSetting(key, info.type);
+        const values = info.type === "enum" ? enumValues.get(key) : undefined;
         entries.push({
           key,
           ...(info.value !== undefined ? { value: info.value } : {}),
           ...(masked ? { value: MASKED_VALUE } : {}),
+          ...(values !== undefined ? { values } : {}),
           type: info.type,
           description: typeof info.description === "string" ? info.description : "",
           masked,
@@ -338,6 +348,35 @@ export class OmpCapabilitiesService {
       }
       return { entries };
     });
+  }
+
+  /**
+   * Enum choices come from the human `omp config list` type column, which
+   * prints them as `(off|idle|display|system)`; `--json` omits them. Any
+   * failure degrades to an empty map so an older binary only loses the
+   * dropdowns, never the settings surface.
+   */
+  private readEnumValues(): Effect.Effect<ReadonlyMap<string, readonly string[]>> {
+    return this.runOmpConfig(["list"]).pipe(
+      Effect.map((result) => {
+        const valuesByKey = new Map<string, readonly string[]>();
+        for (const line of result.stdout.split("\n")) {
+          const match = /^ {2}([^ =]+) = .* \(([^()]*)\)$/.exec(line);
+          if (match === null) continue;
+          const values = match[2]!
+            .split("|")
+            .map((value) => value.trim())
+            .filter((value) => value.length > 0);
+          if (values.length > 0) valuesByKey.set(match[1]!, values);
+        }
+        return valuesByKey;
+      }),
+      Effect.catch(() =>
+        Effect.succeed(
+          new Map<string, readonly string[]>() as ReadonlyMap<string, readonly string[]>,
+        ),
+      ),
+    );
   }
 
   private inventory(

--- a/apps/web/src/components/capabilities/CapabilitiesSettingDialog.tsx
+++ b/apps/web/src/components/capabilities/CapabilitiesSettingDialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import type { EnvironmentId, OmpCapabilityScope, ProjectId } from "@t3tools/contracts";
+import { BracesIcon, ExternalLinkIcon, LoaderIcon, SaveIcon } from "lucide-react";
+import { useState } from "react";
+
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { Button } from "../ui/button";
+import { Dialog, DialogFooter, DialogHeader, DialogPopup, DialogTitle } from "../ui/dialog";
+import { Textarea } from "../ui/textarea";
+import { stackedThreadToast, toastManager } from "../ui/toast";
+
+import type { CapabilitiesSettingsRow } from "./CapabilitiesSettingsPanel";
+import { buildWriteSettingInput, parseSettingDraft } from "./CapabilitiesSettingsPanel.logic";
+
+/** omp settings documentation. */
+const OMP_CONFIG_DOCS_URL = "https://omp.sh/docs/";
+
+interface CapabilitiesSettingDialogProps {
+  readonly entry: CapabilitiesSettingsRow;
+  readonly scope: OmpCapabilityScope;
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId | null;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onMutated: () => void;
+}
+
+/**
+ * Modal editor for a record/array omp config setting: the value is edited as
+ * JSON in a textarea (validated before the write), with a link to the omp
+ * config docs and a Format action that pretty-prints the draft.
+ */
+export function CapabilitiesSettingDialog({
+  entry,
+  scope,
+  environmentId,
+  projectId,
+  onOpenChange,
+  onMutated,
+}: CapabilitiesSettingDialogProps) {
+  const [draft, setDraft] = useState(() => formatSettingValue(entry.value));
+  const [draftError, setDraftError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const writeSetting = useAtomCommand(serverEnvironment.capabilitiesWriteSetting, {
+    label: "capabilities-write-setting",
+  });
+
+  const save = async () => {
+    setBusy(true);
+    const parsed = parseSettingDraft(entry.type, draft);
+    if (!parsed.ok) {
+      setDraftError(parsed.error);
+      setBusy(false);
+      return;
+    }
+    const result = await writeSetting({
+      environmentId,
+      input: buildWriteSettingInput({ key: entry.key, value: parsed.value, scope, projectId }),
+    });
+    setBusy(false);
+    if (result._tag === "Failure") {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: `Could not save ${entry.key}`,
+          description: "Check that omp is installed on the server host and try again.",
+        }),
+      );
+      return;
+    }
+    toastManager.add({ type: "success", title: `Saved ${entry.key}` });
+    onMutated();
+    onOpenChange(false);
+  };
+
+  const formatDraft = () => {
+    try {
+      setDraft(JSON.stringify(JSON.parse(draft), null, 2));
+      setDraftError(null);
+    } catch {
+      setDraftError("Value is not valid JSON.");
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-base">{entry.key}</DialogTitle>
+        </DialogHeader>
+        <div
+          data-slot="dialog-panel"
+          className="space-y-4 p-6 in-[[data-slot=dialog-popup]:has([data-slot=dialog-header])]:pt-1"
+        >
+          <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+                Documentation
+              </p>
+              <a
+                href={OMP_CONFIG_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-foreground/80 underline-offset-2 hover:underline"
+              >
+                Config docs
+                <ExternalLinkIcon className="size-3" aria-hidden />
+              </a>
+            </div>
+            {entry.description.length > 0 ? (
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                {entry.description}
+              </p>
+            ) : null}
+          </div>
+          <div>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+                Value
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-6 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={formatDraft}
+              >
+                <BracesIcon className="size-3" aria-hidden />
+                Format
+              </Button>
+            </div>
+            <Textarea
+              className="mt-1.5 min-h-24 font-mono text-xs"
+              value={draft}
+              onChange={(event) => {
+                setDraft(event.currentTarget.value);
+                setDraftError(null);
+              }}
+              placeholder="Unset"
+              spellCheck={false}
+              aria-label={`Value for ${entry.key}`}
+            />
+          </div>
+          {draftError !== null ? <p className="text-xs text-destructive">{draftError}</p> : null}
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={() => void save()}>
+            {busy ? (
+              <LoaderIcon className="size-3.5 animate-spin" />
+            ) : (
+              <SaveIcon className="size-3.5" />
+            )}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+/**
+ * Pretty-print records/arrays (2-space indent) so the modal opens with a
+ * readable value; primitives render verbatim.
+ */
+function formatSettingValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}

--- a/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.logic.test.ts
@@ -1,17 +1,15 @@
 import { describe, expect, it } from "vite-plus/test";
-import {
-  ProjectId,
-  type OmpCapabilityScope,
-  type OmpSettingsSurfaceEntry,
-} from "@t3tools/contracts";
+import { ProjectId, type OmpSettingsSurfaceEntry } from "@t3tools/contracts";
 
 import {
   buildPrecedenceLabel,
   buildSettingRows,
   buildWriteSettingInput,
   canEditEntry,
-  PRECEDENCE_LADDER,
   filterSettingRows,
+  formatSettingValue,
+  parseSettingDraft,
+  PRECEDENCE_LADDER,
 } from "./CapabilitiesSettingsPanel.logic";
 
 describe("PRECEDENCE_LADDER", () => {
@@ -63,6 +61,17 @@ describe("buildSettingRows", () => {
     expect(rows.map((row) => row.displayValue)).toEqual(["3", "true"]);
   });
 
+  it("serializes records and arrays as JSON instead of [object Object]", () => {
+    const rows = buildSettingRows([
+      entry({ key: "modelRoles", type: "record", value: { default: "openai/gpt-5" } }),
+      entry({ key: "cycleOrder", type: "array", value: ["smol", "default", "slow"] }),
+    ]);
+    expect(rows.map((row) => row.displayValue)).toEqual([
+      '{"default":"openai/gpt-5"}',
+      '["smol","default","slow"]',
+    ]);
+  });
+
   it("renders unset values as an empty string", () => {
     const rows = buildSettingRows([entry({ key: "retries", value: undefined })]);
     expect(rows[0]!.displayValue).toBe("");
@@ -72,6 +81,56 @@ describe("buildSettingRows", () => {
     const source = entry({ key: "theme.dark", type: "boolean", scope: "project" });
     const [row] = buildSettingRows([source]);
     expect(row).toMatchObject({ key: "theme.dark", type: "boolean", scope: "project" });
+  });
+
+  it("carries enum choices through to the row", () => {
+    const source = entry({
+      key: "symbolPreset",
+      type: "enum",
+      values: ["unicode", "nerd", "ascii"],
+    });
+    const [row] = buildSettingRows([source]);
+    expect(row?.values).toEqual(["unicode", "nerd", "ascii"]);
+  });
+});
+
+describe("formatSettingValue", () => {
+  it("stringifies primitives and JSON-encodes structured values", () => {
+    expect(formatSettingValue("titanium")).toBe("titanium");
+    expect(formatSettingValue(true)).toBe("true");
+    expect(formatSettingValue(3)).toBe("3");
+    expect(formatSettingValue({ default: "x" })).toBe('{"default":"x"}');
+    expect(formatSettingValue(["a", "b"])).toBe('["a","b"]');
+    expect(formatSettingValue(undefined)).toBe("");
+    expect(formatSettingValue(null)).toBe("");
+  });
+});
+
+describe("parseSettingDraft", () => {
+  it("parses finite numbers", () => {
+    expect(parseSettingDraft("number", " 5 ")).toEqual({ ok: true, value: 5 });
+    expect(parseSettingDraft("number", "abc").ok).toBe(false);
+    expect(parseSettingDraft("number", "").ok).toBe(false);
+  });
+
+  it("parses JSON arrays", () => {
+    expect(parseSettingDraft("array", '["a","b"]')).toEqual({ ok: true, value: ["a", "b"] });
+    expect(parseSettingDraft("array", '"nope"').ok).toBe(false);
+    expect(parseSettingDraft("array", "{").ok).toBe(false);
+  });
+
+  it("parses JSON records", () => {
+    expect(parseSettingDraft("record", '{"default":"openai/gpt-5"}')).toEqual({
+      ok: true,
+      value: { default: "openai/gpt-5" },
+    });
+    expect(parseSettingDraft("record", "[]").ok).toBe(false);
+    expect(parseSettingDraft("record", "not json").ok).toBe(false);
+  });
+
+  it("passes strings and enums through verbatim", () => {
+    expect(parseSettingDraft("enum", "  auto ")).toEqual({ ok: true, value: "auto" });
+    expect(parseSettingDraft("string", "titanium")).toEqual({ ok: true, value: "titanium" });
   });
 });
 

--- a/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.logic.ts
+++ b/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.logic.ts
@@ -13,6 +13,64 @@ export function buildPrecedenceLabel(scope: OmpCapabilityScope): string {
   return scope === "project" ? PROJECT_LADDER_LABEL : GLOBAL_LADDER_LABEL;
 }
 
+/**
+ * Render a raw omp config value as editable text. Strings/booleans/numbers
+ * stringify verbatim; records and arrays serialize as JSON so the editor
+ * round-trips exactly what `omp config set` parses (JSON for both), instead
+ * of String() collapsing records into "[object Object]".
+ */
+export function formatSettingValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Parse a text draft back into a typed value for the wire, matching the
+ * schema-driven parsing `omp config set` applies. `enum`/`string` are the
+ * only types with no local validation — the omp binary validates enums and
+ * rejects unknown values, which the server surfaces on write.
+ */
+export function parseSettingDraft(
+  type: string,
+  draft: string,
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly error: string } {
+  const trimmed = draft.trim();
+
+  if (type === "number") {
+    if (trimmed.length === 0) return { ok: false, error: "Enter a number." };
+    const value = Number(trimmed);
+    if (!Number.isFinite(value)) return { ok: false, error: `Invalid number: ${draft}.` };
+    return { ok: true, value };
+  }
+
+  if (type === "array") {
+    let value: unknown;
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return { ok: false, error: `Invalid array JSON: ${draft}` };
+    }
+    if (!Array.isArray(value)) return { ok: false, error: `Invalid array JSON: ${draft}` };
+    return { ok: true, value };
+  }
+
+  if (type === "record") {
+    let value: unknown;
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return { ok: false, error: `Invalid record JSON: ${draft}` };
+    }
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return { ok: false, error: `Invalid record JSON: ${draft}` };
+    }
+    return { ok: true, value };
+  }
+
+  return { ok: true, value: trimmed };
+}
+
 export interface SettingsRow extends OmpSettingsSurfaceEntry {
   readonly displayValue: string;
 }
@@ -22,7 +80,7 @@ export function buildSettingRows(
 ): ReadonlyArray<SettingsRow> {
   return entries.map((entry) => ({
     ...entry,
-    displayValue: entry.masked ? "********" : String(entry.value ?? ""),
+    displayValue: entry.masked ? "********" : formatSettingValue(entry.value),
   }));
 }
 

--- a/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.tsx
+++ b/apps/web/src/components/capabilities/CapabilitiesSettingsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
+
 import type {
   EnvironmentId,
   OmpCapabilityScope,
@@ -9,7 +10,7 @@ import type {
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { LoaderIcon, SaveIcon, SearchIcon, Undo2Icon } from "lucide-react";
+import { LoaderIcon, PencilIcon, SaveIcon, SearchIcon, Undo2Icon } from "lucide-react";
 import { useState } from "react";
 
 import { useActiveEnvironmentId } from "../../state/entities";
@@ -20,14 +21,18 @@ import { SettingsPageContainer, SettingsRow, SettingsSection } from "../settings
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 
+import { CapabilitiesSettingDialog } from "./CapabilitiesSettingDialog";
 import {
   buildPrecedenceLabel,
   buildSettingRows,
   buildWriteSettingInput,
   canEditEntry,
   filterSettingRows,
+  formatSettingValue,
+  parseSettingDraft,
 } from "./CapabilitiesSettingsPanel.logic";
 import { resolveCapabilitiesProjectId } from "./CapabilitiesOverviewPanel.logic";
 
@@ -42,15 +47,25 @@ function CapabilitiesSettingRow({
   scope,
   environmentId,
   projectId,
+  onEdit,
   onMutated,
 }: {
   entry: CapabilitiesSettingsRow;
   scope: OmpCapabilityScope;
   environmentId: EnvironmentId;
   projectId: ProjectId | null;
+  onEdit: () => void;
   onMutated: () => void;
 }) {
-  const [draft, setDraft] = useState(entry.masked ? "" : String(entry.value ?? ""));
+  const isBoolean = entry.type === "boolean";
+  const isStructured = entry.type === "record" || entry.type === "array";
+  const enumValues =
+    entry.type === "enum" && (entry.values?.length ?? 0) > 0 ? entry.values : undefined;
+  const [draft, setDraft] = useState(() => (entry.masked ? "" : formatSettingValue(entry.value)));
+  const [booleanDraft, setBooleanDraft] = useState(() =>
+    entry.masked ? false : Boolean(entry.value ?? false),
+  );
+  const [draftError, setDraftError] = useState<string | null>(null);
   const [busy, setBusy] = useState<"save" | "reset" | null>(null);
   const writeSetting = useAtomCommand(serverEnvironment.capabilitiesWriteSetting, {
     label: "capabilities-write-setting",
@@ -58,12 +73,26 @@ function CapabilitiesSettingRow({
   const resetSetting = useAtomCommand(serverEnvironment.capabilitiesResetSetting, {
     label: "capabilities-reset-setting",
   });
+  // Keep the current enum value selectable even when it is stale relative to
+  // the reported choices (e.g. a value written by an older omp version).
+  const selectValues =
+    enumValues !== undefined && draft.length > 0 && !enumValues.includes(draft)
+      ? [draft, ...enumValues]
+      : enumValues;
 
   const save = async () => {
     setBusy("save");
+    const parsed = isBoolean
+      ? ({ ok: true, value: booleanDraft } as const)
+      : parseSettingDraft(entry.type, draft);
+    if (!parsed.ok) {
+      setDraftError(parsed.error);
+      setBusy(null);
+      return;
+    }
     const result = await writeSetting({
       environmentId,
-      input: buildWriteSettingInput({ key: entry.key, value: draft, scope, projectId }),
+      input: buildWriteSettingInput({ key: entry.key, value: parsed.value, scope, projectId }),
     });
     setBusy(null);
     if (result._tag === "Failure") {
@@ -115,37 +144,82 @@ function CapabilitiesSettingRow({
       <td className="px-4 py-2 font-mono font-medium text-foreground sm:pl-5">{entry.key}</td>
       <td className="px-3 py-2 text-muted-foreground">{entry.type}</td>
       <td className="max-w-56 px-3 py-2 text-muted-foreground">{entry.description}</td>
-      <td className="px-3 py-2">
-        {editable ? (
+      <td className="max-w-64 px-3 py-2">
+        {!editable ? (
+          <span className="font-mono text-muted-foreground">{entry.displayValue}</span>
+        ) : isStructured ? (
+          <span className="block truncate font-mono text-xs text-foreground/90">
+            {entry.displayValue}
+          </span>
+        ) : isBoolean ? (
+          <Switch
+            checked={booleanDraft}
+            onCheckedChange={(checked) => {
+              setBooleanDraft(Boolean(checked));
+              setDraftError(null);
+            }}
+            aria-label={`Value for ${entry.key}`}
+          />
+        ) : enumValues !== undefined ? (
+          <Select
+            value={draft}
+            onValueChange={(value) => {
+              if (typeof value === "string") setDraft(value);
+              setDraftError(null);
+            }}
+          >
+            <SelectTrigger className="h-7 w-44" aria-label={`Value for ${entry.key}`}>
+              <SelectValue placeholder="Unset" />
+            </SelectTrigger>
+            <SelectPopup align="end" alignItemWithTrigger={false}>
+              {(selectValues ?? []).map((value) => (
+                <SelectItem hideIndicator key={value} value={value}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        ) : (
           <Input
             size="sm"
             className="h-7 min-w-40 font-mono text-xs"
             value={draft}
-            onChange={(event) => setDraft(event.currentTarget.value)}
+            onChange={(event) => {
+              setDraft(event.currentTarget.value);
+              setDraftError(null);
+            }}
             placeholder="Unset"
             aria-label={`Value for ${entry.key}`}
           />
-        ) : (
-          <span className="font-mono text-muted-foreground">{entry.displayValue}</span>
         )}
+        {draftError !== null && !isStructured ? (
+          <span className="mt-0.5 block text-[11px] text-destructive">{draftError}</span>
+        ) : null}
       </td>
       <td className="px-3 py-2 text-right">
         {editable ? (
           <div className="inline-flex items-center gap-1.5">
-            <Button
-              type="button"
-              size="sm"
-              className="h-7 px-2 text-xs"
-              disabled={busy !== null}
-              onClick={() => void save()}
-            >
-              {busy === "save" ? (
-                <LoaderIcon className="size-3.5 animate-spin" />
-              ) : (
-                <SaveIcon className="size-3.5" />
-              )}
-              Save
-            </Button>
+            {isStructured ? (
+              <Button type="button" size="sm" className="h-7 px-2 text-xs" onClick={onEdit}>
+                <PencilIcon className="size-3.5" />
+                Edit
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                disabled={busy !== null}
+                onClick={() => void save()}
+              >
+                {busy === "save" ? (
+                  <LoaderIcon className="size-3.5 animate-spin" />
+                ) : (
+                  <SaveIcon className="size-3.5" />
+                )}
+                Save
+              </Button>
+            )}
             {hasValue ? (
               <Button
                 type="button"
@@ -155,7 +229,11 @@ function CapabilitiesSettingRow({
                 disabled={busy !== null}
                 onClick={() => void reset()}
               >
-                <Undo2Icon className="size-3.5" />
+                {busy === "reset" ? (
+                  <LoaderIcon className="size-3.5 animate-spin" />
+                ) : (
+                  <Undo2Icon className="size-3.5" />
+                )}
                 Reset
               </Button>
             ) : null}
@@ -176,6 +254,7 @@ export function CapabilitiesSettingsPanel() {
   const projectId = resolveCapabilitiesProjectId(groups, environmentId);
   const [scope, setScope] = useState<OmpCapabilityScope>("global");
   const [query, setQuery] = useState("");
+  const [editingEntryKey, setEditingEntryKey] = useState<string | null>(null);
 
   // Project scope is only available when the active environment has a project.
   const effectiveScope: OmpCapabilityScope =
@@ -226,6 +305,7 @@ export function CapabilitiesSettingsPanel() {
   }
 
   const rows = filterSettingRows(buildSettingRows(snapshot.settings.entries), query);
+  const editingEntry = rows.find((row) => row.key === editingEntryKey) ?? null;
 
   return (
     <SettingsPageContainer>
@@ -298,6 +378,7 @@ export function CapabilitiesSettingsPanel() {
                     scope={effectiveScope}
                     environmentId={environmentId}
                     projectId={projectId}
+                    onEdit={() => setEditingEntryKey(row.key)}
                     onMutated={refreshSnapshot}
                   />
                 ))}
@@ -306,6 +387,19 @@ export function CapabilitiesSettingsPanel() {
           </div>
         )}
       </SettingsSection>
+      {editingEntry !== null ? (
+        <CapabilitiesSettingDialog
+          key={editingEntry.key}
+          entry={editingEntry}
+          scope={effectiveScope}
+          environmentId={environmentId}
+          projectId={projectId}
+          onOpenChange={(open) => {
+            if (!open) setEditingEntryKey(null);
+          }}
+          onMutated={refreshSnapshot}
+        />
+      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/packages/contracts/src/capabilities.test.ts
+++ b/packages/contracts/src/capabilities.test.ts
@@ -51,7 +51,6 @@ const decodeResetSettingTransport = Schema.decodeUnknownSync(
   ServerOmpCapabilitiesResetSettingInput,
 );
 const decodeError = Schema.decodeUnknownSync(OmpCapabilitiesError);
-
 describe("OmpCapabilityScope", () => {
   it("accepts the three scopes", () => {
     expect(OmpCapabilityScope.literals).toEqual(["global", "project", "profile"]);

--- a/packages/contracts/src/capabilities.ts
+++ b/packages/contracts/src/capabilities.ts
@@ -105,6 +105,12 @@ export const OmpSettingsSurfaceEntry = Schema.Struct({
   description: Schema.String,
   masked: Schema.Boolean,
   scope: OmpCapabilityScope,
+  /**
+   * Allowed values for `enum` entries, when the server can discover them
+   * from the omp binary. Absent for every other type (and for enums on
+   * binaries that do not report them) — clients fall back to a text input.
+   */
+  values: Schema.optionalKey(Schema.Array(TrimmedNonEmptyString)),
 });
 export type OmpSettingsSurfaceEntry = typeof OmpSettingsSurfaceEntry.Type;
 


### PR DESCRIPTION
## What Changed

- **Type-aware settings editing** in Capabilities → Settings: booleans edit inline as switches, enums as dropdowns (choices parsed from the human `omp config list` output since `--json` omits them), and strings/numbers as text — with per-row Save/Reset.
- **Records and arrays open in a modal** instead of inline JSON: a pretty-printed (2-space) JSON textarea with a Format action, the setting's description as a Documentation block, a link to the omp config docs (`omp.sh/docs`), and Save validation via `parseSettingDraft`.
- **Server value safety**: global setting writes now serialize non-string values as JSON for `omp config set` (`encodeUnknownJson` via `Schema.fromJsonString`), so records/arrays round-trip instead of being stored as `"[object Object]"`.
- Contracts gain an optional `values` field on `OmpSettingsSurfaceEntry` so enum choices travel to the client; `buildSettingRows` renders records/arrays as JSON.

## Why

The raw config table dumped `[object Object]` for record values, made users hand-type JSON into single-line inputs, and could corrupt records on save. The surface now edits each type with an appropriate control, keeps complex values in a readable JSON modal, and writes them back correctly.

## UI Changes

Capabilities → Settings table: inline switch/dropdown/text controls for scalars, Edit/Reset actions for records and arrays, and a modal editor with pretty-printed JSON, docs link, and Format button. No screenshots captured in this pass.
