### PR TITLE
feat(web): pick role models from a combobox in provider settings

### DIFF
--- a/apps/web/src/components/settings/ModelSlugPicker.tsx
+++ b/apps/web/src/components/settings/ModelSlugPicker.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { CheckIcon, ChevronDownIcon, PlusIcon, SearchIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+  ComboboxTrigger,
+} from "../ui/combobox";
+
+/**
+ * Select-with-search for model slugs in provider settings. The trigger shows
+ * the committed slug (or the placeholder); the popup filters the instance's
+ * known slugs (built-in probe models plus custom models). A typed value that
+ * matches nothing is offered as an "Add" row so custom slugs stay possible
+ * without leaving the picker.
+ */
+export function ModelSlugPicker({
+  ariaLabel,
+  value,
+  slugs,
+  placeholder = "provider/model",
+  onCommit,
+}: {
+  ariaLabel: string;
+  /** Committed slug; empty string means unset. */
+  value: string;
+  /** Known model slugs to offer as choices. */
+  slugs: readonly string[];
+  placeholder?: string | undefined;
+  onCommit: (next: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) setQuery("");
+  };
+
+  const items = useMemo(() => {
+    const trimmed = query.trim();
+    const normalized = trimmed.toLocaleLowerCase();
+    const matches = slugs.filter(
+      (slug) => normalized.length === 0 || slug.toLocaleLowerCase().includes(normalized),
+    );
+    // Creatable fallback: the exact typed slug becomes an "Add" row.
+    return trimmed.length > 0 && !matches.includes(trimmed) ? [...matches, trimmed] : matches;
+  }, [query, slugs]);
+
+  const handlePick = (next: string) => {
+    setOpen(false);
+    onCommit(next);
+  };
+
+  return (
+    <Combobox
+      items={items}
+      filteredItems={items}
+      filter={null}
+      autoHighlight
+      open={open}
+      onOpenChange={handleOpenChange}
+      value={value}
+      onValueChange={(next) => {
+        if (typeof next === "string") handlePick(next);
+      }}
+    >
+      <ComboboxTrigger
+        aria-label={ariaLabel}
+        className="relative inline-flex h-8 w-full min-w-40 cursor-pointer select-none items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-xs text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24 dark:bg-input/32"
+      >
+        <span className="min-w-0 truncate">{value.length === 0 ? placeholder : value}</span>
+        <ChevronDownIcon className="-me-0.5 size-3 shrink-0 text-muted-foreground opacity-50" />
+      </ComboboxTrigger>
+      <ComboboxPopup align="start" className="flex w-72 flex-col">
+        <div className="shrink-0 px-3 pt-2.5">
+          <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+            <SearchIcon
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+            />
+            <ComboboxInput
+              className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+              inputClassName="rounded-none bg-transparent font-mono text-xs"
+              placeholder="Search models…"
+              showTrigger={false}
+              size="sm"
+              unstyled
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex min-h-0 max-h-64 flex-1 flex-col overflow-hidden">
+          <ComboboxEmpty>No matching models</ComboboxEmpty>
+          <ComboboxList className="p-1">
+            {items.map((item, index) => {
+              const isAddRow = query.trim().length > 0 && !slugs.includes(item);
+              return (
+                <ComboboxItem hideIndicator key={item} index={index} value={item}>
+                  <div className="flex w-full min-w-0 items-center justify-between gap-2 font-mono text-xs">
+                    <span className="min-w-0 truncate">{item}</span>
+                    <span className="flex shrink-0 items-center gap-1.5">
+                      {isAddRow ? (
+                        <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                          <PlusIcon className="size-3" />
+                          Add
+                        </span>
+                      ) : item === value ? (
+                        <CheckIcon className="size-3.5 text-muted-foreground" />
+                      ) : null}
+                    </span>
+                  </div>
+                </ComboboxItem>
+              );
+            })}
+          </ComboboxList>
+        </div>
+      </ComboboxPopup>
+    </Combobox>
+  );
+}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -781,6 +781,7 @@ export function ProviderInstanceCard({
                 idPrefix={`provider-instance-${instanceId}`}
                 variant="card"
                 onChange={updateConfig}
+                modelSlugs={modelsForDisplay.map((model) => model.slug)}
               />
             ) : null}
 

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -50,6 +50,21 @@ describe("ProviderSettingsForm helpers", () => {
     });
   });
 
+  it("derives role fields as model controls", () => {
+    const omp = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("omp")];
+    expect(omp).toBeDefined();
+
+    const roleDefault = deriveProviderSettingsFields(omp!).find(
+      (field) => field.key === "roleDefault",
+    );
+    const memoryBackend = deriveProviderSettingsFields(omp!).find(
+      (field) => field.key === "memoryBackend",
+    );
+
+    expect(roleDefault).toMatchObject({ control: "model", placeholder: "provider/model" });
+    expect(memoryBackend?.control).toBe("text");
+  });
+
   it("preserves unknown config keys while omitting empty configurable fields", () => {
     const omp = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("omp")];
     expect(omp).toBeDefined();

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -11,6 +11,7 @@ import type {
 
 import { cn } from "../../lib/utils";
 import { DraftInput } from "../ui/draft-input";
+import { ModelSlugPicker } from "./ModelSlugPicker";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
@@ -160,6 +161,11 @@ interface ProviderSettingsFormProps {
   readonly idPrefix: string;
   readonly variant: "card" | "dialog";
   readonly onChange: (nextConfig: Record<string, unknown> | undefined) => void;
+  /**
+   * Model slugs for the instance, offered as choices by `model`-control
+   * fields. Absent (e.g. before the first provider probe) → plain text input.
+   */
+  readonly modelSlugs?: readonly string[] | undefined;
 }
 
 function FieldFrame(props: {
@@ -178,6 +184,7 @@ interface ProviderSettingsFieldRowProps {
   readonly idPrefix: string;
   readonly variant: ProviderSettingsFormProps["variant"];
   readonly onChange: ProviderSettingsFormProps["onChange"];
+  readonly modelSlugs: ProviderSettingsFormProps["modelSlugs"];
 }
 
 function ProviderSettingsFieldRow({
@@ -186,6 +193,7 @@ function ProviderSettingsFieldRow({
   idPrefix,
   variant,
   onChange,
+  modelSlugs,
 }: ProviderSettingsFieldRowProps) {
   const inputId = `${idPrefix}-${field.key}`;
   const descriptionClassName =
@@ -238,6 +246,26 @@ function ProviderSettingsFieldRow({
     );
   }
 
+  if (field.control === "model" && (modelSlugs?.length ?? 0) > 0) {
+    return (
+      <FieldFrame variant={variant}>
+        <span className={cn("text-xs font-medium text-foreground", variant === "card" && "block")}>
+          {field.label}
+        </span>
+        <div className={cn(variant === "card" && "mt-1.5")}>
+          <ModelSlugPicker
+            ariaLabel={field.label}
+            value={readProviderConfigString(value, field.key)}
+            slugs={modelSlugs ?? []}
+            placeholder={field.placeholder}
+            onCommit={(next) => onChange(nextProviderConfigWithFieldValue(value, field, next))}
+          />
+        </div>
+        {description}
+      </FieldFrame>
+    );
+  }
+
   const type = field.control === "password" ? "password" : undefined;
   return (
     <FieldFrame variant={variant}>
@@ -280,6 +308,7 @@ export function ProviderSettingsForm({
   idPrefix,
   variant,
   onChange,
+  modelSlugs,
 }: ProviderSettingsFormProps) {
   const fields = useMemo(() => deriveProviderSettingsFields(definition), [definition]);
 
@@ -297,6 +326,7 @@ export function ProviderSettingsForm({
           idPrefix={idPrefix}
           variant={variant}
           onChange={onChange}
+          modelSlugs={modelSlugs}
         />
       ))}
     </>

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -223,7 +223,7 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
-export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
+export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch" | "model";
 
 export interface ProviderSettingsFormAnnotation {
   readonly control?: ProviderSettingsFormControl | undefined;
@@ -270,7 +270,11 @@ const makeOmpRoleSetting = (title: string, description: string) =>
     Schema.annotateKey({
       title,
       description,
-      providerSettingsForm: { placeholder: "provider/model", clearWhenEmpty: "omit" },
+      providerSettingsForm: {
+        control: "model",
+        placeholder: "provider/model",
+        clearWhenEmpty: "omit",
+      },
     }),
   );
 


### PR DESCRIPTION
## What Changed

- New `ModelSlugPicker` combobox (searchable, follows the `FontFamilyPicker` pattern) for provider settings fields that take a model slug.
- `ProviderSettingsFormControl` gains a `"model"` control; the omp role fields (`roleDefault`…`roleTiny`) are annotated with it in `OmpSettings`.
- `ProviderInstanceCard` passes the instance's discovered model slugs (probe models + custom) into the form; a typed value that matches nothing becomes an "Add" row so custom slugs stay possible. Fields render a plain text input when no models are discovered yet.

## Why

Role model fields previously required hand-typing exact `provider/model` slugs into a bare text input. The combobox offers the instance's actual model catalog while keeping free-text entry for custom slugs.

## UI Changes

Provider instance cards: role model fields now render as a picker trigger showing the current slug, with a searchable model list and an "Add" row for custom slugs. No screenshots captured in this pass.
