### PR TITLE
fix(server): make omp provider updates publish and settle reliably

### DIFF
--- a/apps/server/src/provider/omp/OmpManagedBinary.ts
+++ b/apps/server/src/provider/omp/OmpManagedBinary.ts
@@ -200,6 +200,33 @@ export const makeOmpManagedBinary = Effect.fn("ompManagedBinary.make")(function*
   const currentPath = path.join(options.baseDir, "tools", "omp", "current", exeName);
   const toolsRoot = path.join(options.baseDir, "tools", "omp");
 
+  /**
+   * Publish a freshly validated binary to `current`, which live sessions run
+   * from. Overwriting it in place with copyFile fails with ETXTBSY ("Text file
+   * busy") while any session is active, so copy to a sibling temp and rename
+   * it over `current`: rename replaces the directory entry atomically and
+   * running processes keep the old inode.
+   */
+  const publishToCurrent = Effect.fn("ompManagedBinary.publishToCurrent")(function* (
+    versionedPath: string,
+  ) {
+    const publishTemp = `${currentPath}.${yield* crypto.randomUUIDv4.pipe(Effect.orDie)}.tmp`;
+    yield* fileSystem
+      .copyFile(versionedPath, publishTemp)
+      .pipe(wrapInstallFailure("write_failed", "Could not stage the managed omp binary."));
+    yield* fileSystem
+      .rename(publishTemp, currentPath)
+      .pipe(
+        wrapInstallFailure("write_failed", "Could not publish omp to the current path."),
+        Effect.ensuring(fileSystem.remove(publishTemp, { force: true }).pipe(Effect.ignore)),
+      );
+    if (platform !== "win32") {
+      yield* fileSystem
+        .chmod(currentPath, 0o755)
+        .pipe(wrapInstallFailure("write_failed", "Could not chmod the current omp binary."));
+    }
+  });
+
   const isExecutableFile = Effect.fn("ompManagedBinary.isExecutableFile")(function* (
     executablePath: string,
   ) {
@@ -433,14 +460,7 @@ export const makeOmpManagedBinary = Effect.fn("ompManagedBinary.make")(function*
       if (yield* isExecutableFile(versionedPath)) {
         const existingVersion = yield* probeVersion(versionedPath);
         if (existingVersion === version) {
-          yield* fileSystem
-            .copyFile(versionedPath, currentPath)
-            .pipe(wrapInstallFailure("write_failed", "Could not activate the managed omp binary."));
-          if (platform !== "win32") {
-            yield* fileSystem
-              .chmod(currentPath, 0o755)
-              .pipe(wrapInstallFailure("write_failed", "Could not chmod the managed omp binary."));
-          }
+          yield* publishToCurrent(versionedPath);
           return {
             status: "available",
             executablePath: currentPath,
@@ -534,14 +554,7 @@ export const makeOmpManagedBinary = Effect.fn("ompManagedBinary.make")(function*
           wrapInstallFailure("write_failed", "Could not activate the versioned omp binary."),
           Effect.ensuring(fileSystem.remove(stagedPath, { force: true }).pipe(Effect.ignore)),
         );
-      yield* fileSystem
-        .copyFile(versionedPath, currentPath)
-        .pipe(wrapInstallFailure("write_failed", "Could not publish omp to the current path."));
-      if (platform !== "win32") {
-        yield* fileSystem
-          .chmod(currentPath, 0o755)
-          .pipe(wrapInstallFailure("write_failed", "Could not chmod the current omp binary."));
-      }
+      yield* publishToCurrent(versionedPath);
 
       return {
         status: "available",

--- a/apps/server/src/provider/omp/RtkManagedBinary.ts
+++ b/apps/server/src/provider/omp/RtkManagedBinary.ts
@@ -412,9 +412,20 @@ export const makeRtkManagedBinary = Effect.fn("rtkManagedBinary.make")(function*
   const activateBinary = Effect.fn("rtkManagedBinary.activateBinary")(function* (
     versionedPath: string,
   ) {
+    // `currentPath` is the binary live rtk sessions run from; overwriting it
+    // in place with copyFile fails with ETXTBSY while any session is active.
+    // Copy to a sibling temp and rename it over `currentPath`: rename replaces
+    // the directory entry atomically and running processes keep the old inode.
+    const publishTemp = `${currentPath}.${yield* crypto.randomUUIDv4.pipe(Effect.orDie)}.tmp`;
     yield* fileSystem
-      .copyFile(versionedPath, currentPath)
-      .pipe(wrapInstallFailure("write_failed", "Could not activate the managed rtk binary."));
+      .copyFile(versionedPath, publishTemp)
+      .pipe(wrapInstallFailure("write_failed", "Could not stage the managed rtk binary."));
+    yield* fileSystem
+      .rename(publishTemp, currentPath)
+      .pipe(
+        wrapInstallFailure("write_failed", "Could not activate the managed rtk binary."),
+        Effect.ensuring(fileSystem.remove(publishTemp, { force: true }).pipe(Effect.ignore)),
+      );
     if (platform !== "win32") {
       yield* fileSystem
         .chmod(currentPath, 0o755)

--- a/apps/server/src/provider/omp/managedBinaryPublish.test.ts
+++ b/apps/server/src/provider/omp/managedBinaryPublish.test.ts
@@ -1,0 +1,77 @@
+// @effect-diagnostics nodeBuiltinImport:off globalTimers:off globalDate:off globalRandom:off globalDateInEffect:off - OS-level test exercises executing-binary overwrite semantics.
+import { describe, expect, it } from "@effect/vitest";
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
+
+/** Real-timer wait — `Effect.sleep` is frozen under the test runtime's TestClock. */
+const wait = (ms: number) =>
+  Effect.promise<void>(() => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+/**
+ * The managed-binary publish (`OmpManagedBinary`, `RtkManagedBinary`) must not
+ * overwrite the `current` binary in place: it is the one live sessions run
+ * from, and an in-place copy over an executing ELF fails with ETXTBSY. The
+ * fix copies to a sibling temp and renames it over `current`. This test pins
+ * the OS invariant that rename replaces an executing file while a plain copy
+ * does not — the reason the publish uses rename.
+ */
+describe("managed binary publish over an executing binary", () => {
+  it.effect("rename replaces an executing ELF where an in-place copy fails", () => {
+    const baseDir = NodePath.join(NodeOS.tmpdir(), `t3-etxtbsy-${Date.now()}-${Math.random()}`);
+    const currentPath = NodePath.join(baseDir, "current", "omp");
+    const newBinaryPath = NodePath.join(baseDir, "new", "omp");
+    NodeFS.mkdirSync(NodePath.join(baseDir, "current"), { recursive: true });
+    NodeFS.mkdirSync(NodePath.join(baseDir, "new"), { recursive: true });
+
+    let child: ReturnType<typeof NodeChildProcess.spawn> | undefined;
+    return Effect.gen(function* () {
+      if (!NodeFS.existsSync("/bin/sleep")) {
+        // The ETXTBSY scenario is Linux-specific; nothing to assert elsewhere.
+        return;
+      }
+
+      // Seed a long-running executable at `current` so its text segment is
+      // ETXTBSY-locked, exactly like a live session, and a distinct new binary.
+      NodeFS.copyFileSync("/bin/sleep", currentPath);
+      NodeFS.chmodSync(currentPath, 0o755);
+      NodeFS.copyFileSync("/bin/true", newBinaryPath);
+      NodeFS.chmodSync(newBinaryPath, 0o755);
+      child = NodeChildProcess.spawn(currentPath, ["30"], { detached: true });
+      child.unref();
+      yield* wait(100);
+
+      // In-place copy fails with ETXTBSY (the bug the publish avoids)…
+      let copyFailedWithBusy = false;
+      try {
+        NodeFS.copyFileSync(newBinaryPath, currentPath);
+      } catch (error) {
+        copyFailedWithBusy =
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          (error as { code?: string }).code === "ETXTBSY";
+      }
+      expect(copyFailedWithBusy).toBe(true);
+
+      // …while copy-to-temp + rename replaces it atomically.
+      const publishTemp = `${currentPath}.${Date.now()}.tmp`;
+      NodeFS.copyFileSync(newBinaryPath, publishTemp);
+      NodeFS.renameSync(publishTemp, currentPath);
+      expect(NodeFS.readFileSync(currentPath).equals(NodeFS.readFileSync(newBinaryPath))).toBe(
+        true,
+      );
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (child) {
+            child.kill("SIGKILL");
+          }
+          NodeFS.rmSync(baseDir, { recursive: true, force: true });
+        }),
+      ),
+    );
+  });
+});

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -532,6 +532,68 @@ describe("providerMaintenanceRunner", () => {
     );
   });
 
+  it.effect("completes an update forked into a daemon after the caller scope closes", () => {
+    const release: { resolve: () => void } = { resolve: () => {} };
+    const releasePromise = new Promise<void>((resolve) => {
+      release.resolve = resolve;
+    });
+    return Effect.gen(function* () {
+      const { registry, updateStatesRef } = yield* makeRegistry();
+      const updater = yield* makeTestRunner(registry);
+
+      // The WebSocket RPC layer runs updates detached from the connection
+      // scope (forkDetach). A client disconnect closes that scope mid-update;
+      // the daemon must survive it and still record the terminal state.
+      const fiber = yield* Effect.scoped(Effect.forkDetach(updater.updateProvider(CODEX_DRIVER)));
+
+      // The command is in flight once the runner records "running"; release it
+      // only then, so the scope above closes while the update is mid-flight.
+      let runningStatus: string | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        runningStatus = (yield* registry.getProviders)[0]?.updateState?.status;
+        if (runningStatus === "running") {
+          break;
+        }
+        yield* Effect.yieldNow;
+      }
+      assert.strictEqual(runningStatus, "running");
+      release.resolve();
+
+      let finalStatus: string | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        finalStatus = (yield* registry.getProviders)[0]?.updateState?.status;
+        if (
+          finalStatus === "succeeded" ||
+          finalStatus === "failed" ||
+          finalStatus === "unchanged"
+        ) {
+          break;
+        }
+        yield* Effect.yieldNow;
+      }
+      assert.strictEqual(finalStatus, "succeeded");
+      assert.deepStrictEqual(
+        (yield* Ref.get(updateStatesRef)).map((state) => state.status),
+        ["queued", "running", "succeeded"],
+      );
+      const exit = yield* Fiber.await(fiber);
+      assert.strictEqual(exit._tag, "Success");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => ({
+            stdout: "updated",
+            exitCode: Effect.promise(() => releasePromise).pipe(
+              Effect.as(ChildProcessSpawner.ExitCode(0)),
+            ),
+          })),
+        ),
+      ),
+    );
+  });
+
   it.effect("serializes different providers that share the same update lock key", () => {
     const firstStartedLatch: { resolve: () => void } = { resolve: () => {} };
     const releaseFirstLatch: { resolve: () => void } = { resolve: () => {} };

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -3,6 +3,7 @@ import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
@@ -1696,7 +1697,19 @@ const makeWsRpcLayer = (
         [WS_METHODS.serverUpdateProvider]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateProvider,
-            providerMaintenanceRunner.updateProvider(input),
+            Effect.gen(function* () {
+              // Run the update detached so a client disconnect (reload,
+              // backgrounding, network blip) cannot interrupt a download or
+              // install that can take minutes, then join so the RPC still
+              // resolves with the terminal provider state — the UI drives its
+              // toast from the RPC result. If the connection drops mid-update
+              // the join is interrupted but the detached update keeps running
+              // server-side, and the registry state survives reconnects.
+              const updateFiber = yield* Effect.forkDetach(
+                providerMaintenanceRunner.updateProvider(input),
+              );
+              return yield* Fiber.join(updateFiber);
+            }),
             {
               "rpc.aggregate": "server",
             },


### PR DESCRIPTION
## What Changed

Fix the managed omp provider update so it publishes and settles reliably:

- **ETXTBSY publish fix** — the install overwrote `tools/omp/current/omp` (and `tools/rtk/current/…`) in place with `copyFile`, which fails with "Text file busy" while live sessions execute that binary. Publish by copying to a sibling temp and `rename` over `current`: rename replaces the directory entry atomically, running processes keep the old inode, and new sessions get the new binary.
- **Update RPC settle fix** — `server.updateProvider` ran the update in the RPC/connection scope, so a disconnect interrupted it; and once detached, it returned before the terminal state, leaving the UI stuck on "updating provider" (the toast is driven by the RPC result, not a live provider stream). Fork the update detached and join it so the RPC resolves with the terminal state while a disconnect only drops the join, never the update.

## Why

`omp update` in the UI failed: the download succeeded but the publish step errored (`ETXTBSY`) while sessions were active, and the update RPC either died on disconnect or left the toast stranded.

## Tests

- Regression: an update forked into a daemon survives the caller scope closing and records the full state sequence.
- OS invariant: rename replaces an executing ELF where an in-place copy fails with `ETXTBSY`.
