### PR TITLE
fix(web): show slash commands in composer after other text

### DIFF
--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -94,6 +94,44 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("detects slash command after other text on the line", () => {
+    const text = "fix this /pl";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "pl",
+      rangeStart: "fix this ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects bare slash after other text", () => {
+    const text = "fix this /";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "",
+      rangeStart: "fix this ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("does not trigger on a slash inside a word", () => {
+    const text = "see https://example.com/foo";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toBeNull();
+  });
+
+  it("closes slash trigger when /model gains arguments after other text", () => {
+    const text = "fix this /model spark";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toBeNull();
+  });
+
   it("detects $skill trigger at cursor", () => {
     const text = "Use $gh-fi";
     const trigger = detectComposerTrigger(text, text.length);

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -224,24 +224,17 @@ export const isCollapsedCursorAdjacentToMention = isCollapsedCursorAdjacentToInl
 
 export function detectComposerTrigger(text: string, cursorInput: number): ComposerTrigger | null {
   const cursor = clampCursor(text, cursorInput);
-  const lineStart = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
-  const linePrefix = text.slice(lineStart, cursor);
-
-  if (linePrefix.startsWith("/")) {
-    const commandMatch = /^\/(\S*)$/.exec(linePrefix);
-    if (commandMatch) {
-      const commandQuery = commandMatch[1] ?? "";
-      return {
-        kind: "slash-command",
-        query: commandQuery,
-        rangeStart: lineStart,
-        rangeEnd: cursor,
-      };
-    }
-  }
-
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
+
+  if (token.startsWith("/")) {
+    return {
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
   if (token.startsWith("$")) {
     return {
       kind: "skill",

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink, serializeComposerMentionPath } from "./composerTrigger.ts";
+import {
+  detectComposerTrigger,
+  serializeComposerFileLink,
+  serializeComposerMentionPath,
+} from "./composerTrigger.ts";
 
 describe("serializeComposerMentionPath", () => {
   it("keeps simple mention paths unquoted", () => {
@@ -39,5 +43,98 @@ describe("serializeComposerFileLink", () => {
     expect(serializeComposerFileLink("@scope/package.json")).toBe(
       "[package.json](@scope/package.json)",
     );
+  });
+});
+
+describe("detectComposerTrigger", () => {
+  it("detects slash command at the start of the prompt", () => {
+    const text = "/pl";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "pl",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects slash command after other text on the line", () => {
+    const text = "fix this /pl";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "pl",
+      rangeStart: "fix this ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("keeps /model as slash-model with no query", () => {
+    const text = "/model";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-model",
+      query: "",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("keeps /model active while its argument is typed", () => {
+    const text = "/model spark";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-model",
+      query: "spark",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("keeps /model active mid-line while its argument is typed", () => {
+    const text = "switch /model spark";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-model",
+      query: "spark",
+      rangeStart: "switch ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects $skill trigger after other text", () => {
+    const text = "run $gh-fi";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "skill",
+      query: "gh-fi",
+      rangeStart: "run ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects @path trigger after other text", () => {
+    const text = "check @src/com";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "path",
+      query: "src/com",
+      rangeStart: "check ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("does not trigger on a slash inside a word", () => {
+    const text = "see https://example.com/foo";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toBeNull();
   });
 });

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -52,6 +52,10 @@ function isWhitespace(char: string): boolean {
 /**
  * Detect an active trigger (@path, $skill, /command) at the cursor position.
  *
+ * Slash commands, like $skills and @paths, trigger at the start of a
+ * whitespace-delimited token — not only at the start of the line — so
+ * "/plan" typed after other text still opens the command menu.
+ *
  * Accepts an optional `isWhitespaceChar` override so callers with inline
  * placeholder characters (e.g. terminal context chips on web) can treat
  * those as token boundaries.
@@ -62,48 +66,48 @@ export function detectComposerTrigger(
   isWhitespaceChar?: (char: string) => boolean,
 ): ComposerTrigger | null {
   const cursor = clampCursor(text, cursorInput);
-  const lineStart = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
-  const linePrefix = text.slice(lineStart, cursor);
-
-  if (linePrefix.startsWith("/")) {
-    const commandMatch = /^\/(\S*)$/.exec(linePrefix);
-    if (commandMatch) {
-      const commandQuery = commandMatch[1] ?? "";
-      if (commandQuery.toLowerCase() === "model") {
-        return {
-          kind: "slash-model",
-          query: "",
-          rangeStart: lineStart,
-          rangeEnd: cursor,
-        };
-      }
-      return {
-        kind: "slash-command",
-        query: commandQuery,
-        rangeStart: lineStart,
-        rangeEnd: cursor,
-      };
-    }
-
-    const modelMatch = /^\/model(?:\s+(.*))?$/.exec(linePrefix);
-    if (modelMatch) {
-      return {
-        kind: "slash-model",
-        query: (modelMatch[1] ?? "").trim(),
-        rangeStart: lineStart,
-        rangeEnd: cursor,
-      };
-    }
-  }
-
   const wsCheck = isWhitespaceChar ?? isWhitespace;
+
   let tokenIdx = cursor - 1;
   while (tokenIdx >= 0 && !wsCheck(text[tokenIdx] ?? "")) {
     tokenIdx -= 1;
   }
   const tokenStart = tokenIdx + 1;
-
   const token = text.slice(tokenStart, cursor);
+
+  if (token.startsWith("/")) {
+    const commandQuery = token.slice(1);
+    if (commandQuery.toLowerCase() === "model") {
+      return {
+        kind: "slash-model",
+        query: "",
+        rangeStart: tokenStart,
+        rangeEnd: cursor,
+      };
+    }
+    return {
+      kind: "slash-command",
+      query: commandQuery,
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
+
+  // Keep /model active while its argument is being typed ("/model spark"),
+  // wherever on the line it appears.
+  const lineStart = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
+  const linePrefix = text.slice(lineStart, cursor);
+  const modelMatch = /(?:^|\s)\/model(?:\s+(.*))?$/i.exec(linePrefix);
+  if (modelMatch) {
+    const slashIndex = modelMatch.index + modelMatch[0].search(/\/model/i);
+    return {
+      kind: "slash-model",
+      query: (modelMatch[1] ?? "").trim(),
+      rangeStart: lineStart + slashIndex,
+      rangeEnd: cursor,
+    };
+  }
+
   if (token.startsWith("$")) {
     return {
       kind: "skill",


### PR DESCRIPTION
## What Changed

- Typing `/` after other text now opens the composer command menu — `/plan`, `/model`, and provider commands (e.g. `/ui`) trigger mid-prompt, not only at the start of a line.
- Fixed in both trigger implementations: `apps/web/src/composer-logic.ts` (web/desktop) and `packages/shared/src/composerTrigger.ts` (mobile). Slash detection now scans whitespace-delimited tokens like $skills and @paths already did; `rangeStart` is the token start so selection replacement stays correct.
- Mobile's `/model <args>` active-trigger continuation is preserved, now also mid-line.
- Slashes inside words (`https://example.com/foo`) still don't trigger.

## Why

`/` commands were unreachable mid-prompt: `detectComposerTrigger` required the slash to be the first character of the line, unlike $skill and @path triggers. The command/skill menu simply never appeared.

## UI Changes

N/A — no visual layout change. Behavior: the command menu now appears when typing `/` after other text (previously only at line start). Covered by 12 new unit tests (web + shared); all 57 tests pass.