### PR TITLE
docs: scope integrated client pass to behavior changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Bypass for a single command: `VP_GIT_HOOKS=0 git commit` / `VP_GIT_HOOKS=0 git p
 - **Do not run repo-wide checks.** No `vp check`, no `vp run -r test`, no `vp run -r typecheck` unless I ask. CI owns the full suite. Hooks still run on commit/push unless `VP_GIT_HOOKS=0`.
 - Backend behavior changes ship with focused tests for that behavior.
 - The server is event-sourced and its async flows emit typed receipts. Wait on receipts and worker drains, never on sleeps or polling. A test that needs a timeout to pass is wrong.
-- Upon request, user-visible frontend changes should get one integrated pass in a real client: `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does this once after integrating. Subagents do not launch their own dev servers. Ask permission before doing computer use or spinning up browsers.
+- Upon request, user-visible behavior changes should get one integrated pass in a real client: `test-t3-app` for web, `test-t3-mobile` for mobile. The primary agent does this once after integrating. Subagents do not launch their own dev servers. Ask permission before doing computer use or spinning up browsers.
 
 ## Pull requests
 


### PR DESCRIPTION
## What Changed

- AGENTS.md: the "integrated pass in a real client" line now applies to user-visible **behavior** changes, not all frontend changes. Branding, icon, and static-asset changes no longer imply a client pass.

## Why

A client pass and screenshots add nothing for branding/asset-only changes; the previous wording signaled one was expected for every frontend change.

## UI Changes

N/A — repo guidance only.