### PR TITLE
docs(user): point install docs at Pivot instead of T3 Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,17 +18,17 @@ Lots of apps have gotten bogged down with bad tech decisions and "slop". We have
 
 ### 3. Remote ready
 
-The architecture of T3 Code's websocket layer (npx t3) enables a lot of awesome remote features. These have become core to the product. Whether users are connecting directly over their local network, using Tailscale, or leaning in fully with T3 Connect (our tunnel solution, also in this repo), we need to make sure new features are properly supported.
+The architecture of Pivot's websocket layer (npx pivot-cli) enables a lot of awesome remote features. These have become core to the product. Whether users are connecting directly over their local network, using Tailscale, or through a tunnel, we need to make sure new features are properly supported.
 
 ### 4. Multi-surface
 
 T3 Code has 3 key app surfaces: **web**, **desktop**, and **mobile**.
 
-**Web** is kind of two surfaces, as we have the public facing "app.t3.codes" as well as locally hosting the web app through the `npx t3` command. Both need to be supported by all new features where reasonable.
+**Web** is the locally hosted web app served through the `npx pivot-cli` command. This fork has no hosted web app.
 
-**Desktop** is the main surface most users install first. It's a full Electron app that bundles the server runner as well. The desktop app can also be used as the host server, allowing remote connections from app.t3.codes or the mobile app.
+**Desktop** is the main surface most users install first. It's a full Electron app that bundles the server runner as well. The desktop app can also be used as the host server, allowing remote connections from the mobile app or other clients.
 
-**Mobile** is a React Native app for both iOS and Android, available on the App Store and Google Play. The mobile app allows for connecting to any T3 Code server to control work remotely.
+**Mobile** is a React Native app for both iOS and Android, available on the App Store and Google Play. The mobile app allows for connecting to any Pivot server to control work remotely.
 
 ## A note from Theo
 
@@ -68,7 +68,7 @@ The most common defect in this repo is a change that works on the path you teste
 
 - **Entry points.** A behavior reachable from the chat view is usually also reachable from Settings, the command palette, and a keybinding. Fixing one is not fixing the feature.
 - **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile (React Native, separate navigation). Shared logic lives in `packages/client-runtime`
-- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here".
+- **Providers.** Pivot ships one built-in driver: omp. Provider-shaped features are scoped to omp only.
 - **Contracts.** Anything crossing the wire is typed in `packages/contracts`. Change the schema and the server, web, mobile, and desktop all follow.
 - **Reverse states.** If you added a way in, add the way out and the way to see it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
 - **Connection modes.** Local, remote/relay, and tunnel behave differently. Multi-device and multi-environment cases are real.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,7 +1,7 @@
-# T3 Code Mobile
+# Piπot Mobile
 
 > [!WARNING]
-> T3 Code Mobile is currently in development and is not distributed yet. If you want to try it out, you can build it from source.
+> Piπot Mobile is currently in development and is not distributed yet. If you want to try it out, you can build it from source.
 
 ## Quickstart
 
@@ -10,14 +10,14 @@
 
 This app has three variants:
 
-- `development`: Expo dev client, installable side-by-side as `T3 Code Dev`
-- `preview`: persistent internal preview build, installable side-by-side as `T3 Code Preview`
-- `production`: store/release build as `T3 Code`
+- `development`: Expo dev client, installable side-by-side as `Piπot Dev`
+- `preview`: persistent internal preview build, installable side-by-side as `Piπot Preview`
+- `production`: store/release build as `Piπot`
 
 Run commands from `apps/mobile`.
 
-T3 Connect is optional and disabled in a fresh clone. Public configuration belongs in the
-repository-root `.env` or `.env.local`, not an `apps/mobile/.env` file. See
+Cloud features (relay/T3 Connect) are optional and disabled in a fresh clone. Public configuration
+belongs in the repository-root `.env` or `.env.local`, not an `apps/mobile/.env` file. See
 [`../../.env.example`](../../.env.example).
 
 ## Development
@@ -40,7 +40,7 @@ entitlement, and native Sign in with Apple entitlement; builds without this opt-
 
 ```bash
 T3CODE_IOS_PERSONAL_TEAM=1 \
-T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID=com.example.t3code.dev \
+T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID=com.example.pivot.dev \
 vp run ios:dev
 ```
 
@@ -54,7 +54,7 @@ The Personal Team equivalent also needs a unique bundle identifier:
 
 ```bash
 T3CODE_IOS_PERSONAL_TEAM=1 \
-T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID=com.example.t3code \
+T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID=com.example.pivot \
 vp run ios:release
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# T3 Code docs
+# Pivot docs
 
-## Using T3 Code
+## Using Pivot
 
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
@@ -18,7 +18,7 @@ Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 
 ---
 
-## Working on T3 Code
+## Working on Pivot
 
 Everything below is for maintainers. Setup lives in the [root README](../README.md);
 policy in [CONTRIBUTING.md](../CONTRIBUTING.md); agent rules in [AGENTS.md](../AGENTS.md).

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -1,6 +1,6 @@
 # CI quality gates
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs four jobs on pull requests and
 pushes to `main`:

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -1,6 +1,6 @@
 # Connection Runtime
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 The connection runtime is shared by web and mobile. It owns connectivity,
 authentication, retries, transport lifetime, cached environment data, and

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -1,6 +1,6 @@
 # Environment Authentication Profile
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 The environment server and the relay use separate credentials, issuers, and trust
 boundaries. They intentionally use a similar OAuth-shaped model so that permission

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -1,8 +1,8 @@
 # Glossary
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
-This is a living glossary for T3 Code. It explains what common terms mean in this codebase.
+This is a living glossary for Pivot. It explains what common terms mean in this codebase.
 
 ## Table of contents
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -1,8 +1,8 @@
 # Architecture
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
-T3 Code is a server runtime that owns agent sessions, workspaces, and version control, plus clients
+Pivot is a server runtime that owns agent sessions, workspaces, and version control, plus clients
 (web, desktop, mobile) that talk to it over one authenticated Effect RPC WebSocket. The server is the
 execution boundary: every provider process, terminal, git operation, and filesystem read happens
 there, never in the client.
@@ -18,13 +18,12 @@ there, never in the client.
 ┌──────────────────▼─────────────────────────────┐
 │ apps/server                                    │
 │  orchestration engine (event-sourced)          │
-│  provider driver registry (5 built-in drivers) │
+│  provider driver registry (1 driver: omp)      │
 │  checkpointing, VCS, terminals, filesystem     │
 └──────────────────┬─────────────────────────────┘
                    │ per-driver transport
 ┌──────────────────▼─────────────────────────────┐
-│ Agent CLIs: Codex, Claude, Cursor, Grok,       │
-│ OpenCode                                       │
+│ Agent CLI: omp                                 │
 └────────────────────────────────────────────────┘
 ```
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -1,6 +1,6 @@
 # Provider architecture
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 A provider is the agent runtime that does the actual work. Pivot ships one built-in driver: omp.
 The orchestration layer does not know which driver is behind a thread; it consumes normalized

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -1,6 +1,6 @@
 # Remote Architecture
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 Remote environments are shipped, not planned. Direct, bearer-paired, relay-tunneled, Tailscale, and
 desktop-managed SSH access all exist today. This document describes the model they share and where

--- a/docs/internals/resource-telemetry.md
+++ b/docs/internals/resource-telemetry.md
@@ -1,6 +1,6 @@
 # Resource telemetry architecture
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 Status: implemented
 

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -1,10 +1,10 @@
 # Scripts
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 ## First checkout
 
-T3 Code uses [Vite+](https://viteplus.dev/guide/). Install the global `vp` command, install
+Pivot uses [Vite+](https://viteplus.dev/guide/). Install the global `vp` command, install
 dependencies, then start the dev stack:
 
 ```bash
@@ -78,9 +78,9 @@ authenticated.
 
 - Default build is unsigned/not notarized for local sharing.
 - The DMG build uses `assets/prod/black-macos-1024.png` as the production app icon source.
-- Desktop production windows load the bundled UI from the `t3code://app/` root URL (not a
+- Desktop production windows load the bundled UI from the `pivot://app/` root URL (not a
   `127.0.0.1` document URL, and not an explicit `index.html` path).
-- Desktop packaging includes `apps/server/dist` (the `t3` backend) and starts it on loopback with an
+- Desktop packaging includes `apps/server/dist` (the `pivot` backend) and starts it on loopback with an
   auth token for WebSocket/API traffic.
 - Your tester can still open it on macOS by right-clicking the app and choosing **Open** on first
   launch.

--- a/docs/internals/server-updates.md
+++ b/docs/internals/server-updates.md
@@ -1,6 +1,6 @@
 # Server Update Architecture
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 Remote server updates use one stable systemd launcher. Foreground CLI processes do not self-update,
 and a running server never edits its systemd unit or durable service state.

--- a/docs/internals/t3-connect.md
+++ b/docs/internals/t3-connect.md
@@ -1,6 +1,6 @@
 # T3 Connect
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 T3 Connect uses one Clerk application for web, desktop, and mobile authentication. The relay verifies
 two kinds of bearer credential: template JWTs generated from the `t3-relay` template with the shared

--- a/docs/internals/workspace-layout.md
+++ b/docs/internals/workspace-layout.md
@@ -1,6 +1,6 @@
 # Workspace layout
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 A pnpm workspace driven by [vite-plus](https://vite.plus) (`vp`). See [scripts.md](./scripts.md) for
 the task commands.
@@ -12,8 +12,8 @@ the task commands.
   Also serves the built web app.
 - `apps/web` (`@t3tools/web`): React + Vite UI. Consumes the shared client runtime and adds routing,
   components, and web-specific platform layers.
-- `apps/desktop` (`@t3tools/desktop`): Electron shell. Supervises a desktop-scoped `t3` backend,
-  loads the web bundle over the `t3code://` protocol, and owns SSH-managed remote environments.
+- `apps/desktop` (`@t3tools/desktop`): Electron shell. Supervises a desktop-scoped `pivot` backend,
+  loads the web bundle over the `pivot://` protocol, and owns SSH-managed remote environments.
 - `apps/mobile` (`@t3tools/mobile`): Expo/React Native client. Same client runtime composition as
   web, different platform layer and UI.
 - `apps/marketing` (`@t3tools/marketing`): Astro marketing site.

--- a/docs/operations/mobile-app-store-screenshots.md
+++ b/docs/operations/mobile-app-store-screenshots.md
@@ -1,6 +1,6 @@
 # Mobile app-store screenshot harness
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 The screenshot harness runs the real mobile application against three disposable local T3
 environments. It creates an isolated base directory and server for each environment, real Git

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,8 +1,8 @@
 # Observability
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
-T3 Code has one server-side observability model:
+Pivot has one server-side observability model:
 
 - pretty logs go to stdout for humans
 - completed spans go to a local NDJSON trace file
@@ -155,7 +155,7 @@ macOS app bundle example:
 T3CODE_OTLP_TRACES_URL=http://localhost:4318/v1/traces \
 T3CODE_OTLP_METRICS_URL=http://localhost:4318/v1/metrics \
 T3CODE_OTLP_SERVICE_NAME=t3-desktop \
-"/Applications/T3 Code.app/Contents/MacOS/T3 Code"
+"/Applications/Pivot (Alpha).app/Contents/MacOS/Pivot (Alpha)"
 ```
 
 Direct binary example:

--- a/docs/operations/relay-observability.md
+++ b/docs/operations/relay-observability.md
@@ -1,6 +1,6 @@
 # Relay observability
 
-> For maintainers. Using T3 Code? See [docs/user](../user/).
+> For maintainers. Using Pivot? See [docs/user](../user/).
 
 The relay Alchemy stack owns a shared Axiom trace setup:
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -4,7 +4,7 @@
 
 This document covers the unified release workflow for stable and nightly releases
 on this repository (**desktop + CLI**). Hosted web (Vercel) and **T3 Connect** are
-not part of this release path. Use local web (`pnpm run dev` / `npx t3`) instead.
+not part of this release path. Use local web (`pnpm run dev` / `npx pivot-cli`) instead.
 
 ## What the workflow does
 

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -38,12 +38,4 @@ launcher snapshots the database before a remote candidate starts, so database up
 with the server version. An older launcher may require one local `service update` before this is
 available.
 
-## Using It with T3 Connect
-
-T3 Connect may offer to install the service during setup so the host stays reachable after you log
-out. This is only an onboarding shortcut: the service and T3 Connect are managed separately.
-
-Signing out of T3 Connect does not remove the service. Use `pivot service uninstall` when you no longer
-want Pivot to start in the background.
-
 The background service currently requires Linux with systemd.

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -20,26 +20,10 @@ This starts the Pivot server on your machine and opens the local web app. Use
 ## Desktop App
 
 Download the latest release from
-[GitHub Releases](https://github.com/pingdotgg/t3code/releases), or install from a package
-registry.
+[GitHub Releases](https://github.com/13kparkin/Pivot/releases).
 
-Windows:
-
-```bash
-winget install T3Tools.T3Code
-```
-
-macOS:
-
-```bash
-brew install --cask t3-code
-```
-
-Arch Linux:
-
-```bash
-yay -S t3code-bin
-```
+Pivot is not published to winget, Homebrew, or the AUR yet — GitHub Releases is the
+desktop distribution channel.
 
 ## Providers
 

--- a/docs/user/providers-omp.md
+++ b/docs/user/providers-omp.md
@@ -25,7 +25,7 @@ Unsupported hosts (for example linux musl on arm64 for rtk) fail Install with a 
 
 Model lists come from omp (`get_available_models`), not from a hardcoded catalog in Pivot. omp models expose **Thinking** and **Fast mode** controls in the composer when the model supports them.
 
-Login runs on the machine hosting the T3 server (browser opens there; OAuth callbacks stay there). You can also sign in from a terminal on that host with `omp login`.
+Login runs on the machine hosting the Pivot server (browser opens there; OAuth callbacks stay there). You can also sign in from a terminal on that host with `omp login`.
 
 When omp asks for a confirmation, a paste code, a proposed host-URI edit, or a choice (including login paste prompts), Pivot shows the existing approval / user-input panels in the composer. Your answer is sent back to omp over RPC (`extension_ui_response` or `host_uri_result`).
 

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -51,12 +51,12 @@ The default endpoint controls the QR code and primary copy action for pairing li
 When no user default is saved, the app uses the built-in LAN endpoint for pairing links when
 available. You can set another endpoint as the default from the expanded endpoint list.
 
-- HTTPS/WSS-compatible endpoints work from `https://app.t3.codes`, but are not made the default
-  automatically.
+- HTTPS/WSS endpoints are required when the web app is opened over HTTPS (for example Tailscale Serve),
+  but are not made the default automatically.
 - Non-loopback HTTP endpoints are useful for direct LAN pairing.
 - Loopback-only endpoints are not useful for another device unless that device is the same machine.
 
-If the copied link points directly at `http://192.168.x.y:3773`, open it from a client that can reach that LAN address. If it points at `https://app.t3.codes/pair?...`, the hosted web app will save the environment and connect directly to the backend URL in the link.
+If the copied link points directly at `http://192.168.x.y:3773`, open it from a client that can reach that LAN address. If it points at a pairing URL like `http://192.168.x.y:3773/pair#token=…`, the server's web app opens, saves the environment, and connects directly to that backend URL.
 
 In the mobile app's **Add Environment** form, a numeric IP address without a scheme uses HTTP. Include `https://` explicitly when the backend is served over HTTPS.
 
@@ -78,7 +78,7 @@ Tailscale Serve to proxy HTTPS traffic to the local backend. Turn the same switc
 
 The Tailscale support is an endpoint provider add-on. The core remote model still works without Tailscale: LAN HTTP endpoints, custom HTTPS endpoints, future tunnels, and SSH-launched environments all use the same saved environment and pairing flow.
 
-For `https://app.t3.codes`, prefer an HTTPS Tailnet or other HTTPS endpoint. A plain `http://100.x.y.z:3773` endpoint can still work from a desktop client or another browser page served over HTTP, but it will not work from the hosted HTTPS app because of browser mixed-content rules.
+When the web app is served over HTTPS (for example `https://machine.tailnet.ts.net/`), prefer an HTTPS Tailnet or other HTTPS endpoint. A plain `http://100.x.y.z:3773` endpoint can still work from a desktop client or another browser page served over HTTP, but it will not work from the HTTPS web app because of browser mixed-content rules.
 
 ### Option 2: Headless Server (CLI)
 
@@ -102,7 +102,7 @@ From there, connect from another device in either of these ways:
 - scan the QR code on your phone
 - in the desktop app, enter the full pairing URL
 - in the desktop app, enter the host and token separately
-- in the hosted web app, open a hosted pairing URL when the backend is reachable over HTTPS
+- in any browser, open the pairing URL; when the web app is served over HTTPS, the backend must be reachable over HTTPS/WSS
 
 Use `pivot serve --help` for the full flag reference. It supports the same general startup options as the normal server command, including an optional `cwd` argument.
 
@@ -130,15 +130,15 @@ Use this when you want the desktop app to start or reuse Pivot on another machin
 2. Under **Remote Environments**, choose **Add environment**.
 3. Select the SSH launch flow.
 4. Enter the SSH target, such as `user@example.com`.
-5. Confirm the launch. The desktop app probes the host, starts or reuses a remote T3 server, opens a local port forward, and saves the environment.
+5. Confirm the launch. The desktop app probes the host, starts or reuses a remote Pivot server, opens a local port forward, and saves the environment.
 
-After setup, the renderer connects to a local forwarded HTTP/WebSocket endpoint. The remote host still owns the actual T3 server, projects, files, git state, terminals, and provider sessions.
+After setup, the renderer connects to a local forwarded HTTP/WebSocket endpoint. The remote host still owns the actual Pivot server, projects, files, git state, terminals, and provider sessions.
 
 SSH launch is a desktop feature because it needs local process and SSH access. Once the environment is paired and saved, it uses the same environment list and connection model as direct LAN, Tailscale, HTTPS, or future tunnel-backed environments.
 
 #### SSH Launch Troubleshooting
 
-The desktop SSH launcher connects with a non-interactive `sh` session, writes a small launcher script under `~/.t3/ssh-launch/<host-key>/`, starts or reuses a remote T3 server, and forwards the remote loopback port back to your desktop.
+The desktop SSH launcher connects with a non-interactive `sh` session, writes a small launcher script under `~/.t3/ssh-launch/<host-key>/`, starts or reuses a remote Pivot server, and forwards the remote loopback port back to your desktop.
 
 The remote host must have a compatible Node.js runtime. Pivot uses the server package's `engines.node` requirement:
 
@@ -192,19 +192,19 @@ Instead:
 
 After pairing, future access is session-based. You do not need to keep reusing the original token unless you are pairing a new device.
 
-## Hosted Web App Pairing
+## Web App Pairing
 
-The hosted web app at `https://app.t3.codes` can save a remote backend in browser local storage from a URL like:
+Pairing URLs point at the server's own origin and open its web app, which saves the backend in browser local storage and connects directly to it:
 
 ```text
-https://app.t3.codes/pair?host=https://backend.example.com:3773#token=PAIRCODE
+https://backend.example.com:3773/pair#token=PAIRCODE
 ```
 
-Use hosted pairing when the backend is reachable from the browser over HTTPS/WSS. This includes a backend behind a trusted HTTPS tunnel or another HTTPS endpoint you operate.
+Use the pairing URL when the backend is reachable from the browser over HTTPS/WSS. This includes a backend behind a trusted HTTPS tunnel or another HTTPS endpoint you operate.
 
-Do not use hosted pairing for plain HTTP LAN URLs such as `http://192.168.x.y:3773`. Browsers block an HTTPS page from connecting to an insecure HTTP or WS backend. For those endpoints, use the direct pairing URL shown by the desktop app or CLI from a client that can open that HTTP URL directly.
+Do not open the pairing URL from an HTTPS page when the backend is a plain HTTP LAN URL such as `http://192.168.x.y:3773`. Browsers block an HTTPS page from connecting to an insecure HTTP or WS backend. For those endpoints, open the pairing URL from a client that can open that HTTP URL directly.
 
-Hosted pairing does not proxy traffic through Pivot. The browser still connects directly to the backend URL in the pairing link.
+Pairing does not proxy traffic through Pivot. The browser still connects directly to the backend URL in the pairing link.
 
 ## Managing Access Later
 
@@ -218,21 +218,10 @@ Typical uses:
 
 Use `pivot auth --help` and the nested subcommand help pages for the full reference.
 
-### Deregister a T3 Connect Environment
-
-Open your account menu and choose **T3 Connect** to see every environment registered to your
-account. On mobile, open **Settings** → **T3 Connect**. Choose **Deregister** to revoke an
-environment's T3 Connect access, remove any managed tunnel, and free its host space.
-
-Deregistration is an account action and does not need a connection to the environment, so it also
-works for a server that was wiped or is no longer reachable. Device-local connect and disconnect
-controls remain in **Settings** → **Connections** on web and desktop or **Settings** →
-**Environments** on mobile.
-
 ## Security Notes
 
 - Treat pairing URLs and pairing tokens like passwords.
 - Prefer binding `--host` to a trusted private address, such as a Tailnet IP, instead of exposing the server broadly.
 - Anyone with a valid pairing credential can create a session until that credential expires or is revoked.
-- Hosted pairing links keep the credential in the URL hash so it is not sent to the hosted app server, but it can still be exposed through browser history, screenshots, logs, or copy/paste.
+- Pairing links keep the token in the URL hash, but it can still be exposed through browser history, screenshots, logs, or copy/paste.
 - Use `pivot auth` to revoke credentials or sessions you no longer trust.


### PR DESCRIPTION
## What Changed

- `docs/user/install.md` — desktop downloads point at `13kparkin/Pivot` releases; removed upstream winget/brew/AUR install commands Pivot doesn't publish.
- `docs/user/remote-access.md` — pairing docs now describe the server-origin pairing URL (`/pair#token=…`) instead of the `app.t3.codes` hosted app; removed the T3 Connect deregister section; "T3 server" → "Pivot server".
- `docs/user/background-service.md` — removed the T3 Connect section (feature disabled for this fork).
- `docs/user/providers-omp.md` — "T3 server" → "Pivot server".
- `docs/README.md` and maintainer header lines across `docs/internals/*` / `docs/operations/*` — "T3 Code" → "Pivot".
- `docs/internals/overview.md` — provider diagram corrected to the single omp driver.
- `docs/internals/scripts.md` / `workspace-layout.md` — `t3code://` → `pivot://`, `t3` backend → `pivot` backend.
- `docs/operations/observability.md` — app bundle path example updated.
- `docs/operations/release.md` — `npx t3` → `npx pivot-cli`.
- `AGENTS.md` — `npx t3` → `npx pivot-cli`; removed hosted-app and T3 Connect claims; provider list corrected to omp-only.
- `apps/mobile/README.md` — "T3 Code Mobile" → "Piπot Mobile"; variant names and bundle-id examples aligned with `app.config.ts`.

## Why

The fork's docs still pointed users at upstream T3 Code install channels — `pingdotgg/t3code` releases, winget/brew/AUR packages, the `app.t3.codes` hosted app, and T3 Connect — none of which exist for Pivot. Updated to Pivot's real channels: `npx pivot-cli`, `13kparkin/Pivot` releases, and server-origin pairing.

## UI Changes

N/A — docs and README only.
