### PR TITLE
feat(web): collapse status points individually

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -4,6 +4,7 @@ import { type LegendListRef } from "@legendapp/list/react-native";
 import type { EnvironmentId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
 import { CHAT_LIST_ANCHOR_OFFSET, resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
 import { formatElapsed } from "@t3tools/shared/orchestrationTiming";
+import { splitStatusPoints } from "@t3tools/client-runtime/state/status-points";
 import { SymbolView } from "../../components/AppSymbol";
 import { HeaderHeightContext } from "@react-navigation/elements";
 import { useNavigation } from "@react-navigation/native";
@@ -976,7 +977,6 @@ function renderFeedEntry(
         {message.statusText ? (
           <AssistantStatusSection
             statusText={message.statusText}
-            initiallyExpanded={message.text.trim().length === 0}
             iconSubtleColor={iconSubtleColor}
             markdownStyles={styles}
             skills={props.skills}
@@ -1071,15 +1071,32 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
 
 function AssistantStatusSection(props: {
   readonly statusText: string;
-  readonly initiallyExpanded: boolean;
   readonly iconSubtleColor: ColorValue;
   readonly markdownStyles: MarkdownStyleSet;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly onLinkPress: (href: string) => void;
 }) {
-  const [expanded, setExpanded] = useState(props.initiallyExpanded);
+  const points = splitStatusPoints(props.statusText);
+  const [expanded, setExpanded] = useState(false);
+  const [expandedPoints, setExpandedPoints] = useState<ReadonlySet<number>>(new Set());
   const colorScheme = useColorScheme();
   const pressedBackground = colorScheme === "dark" ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.035)";
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  const togglePoint = (index: number) => {
+    setExpandedPoints((previous) => {
+      const next = new Set(previous);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
 
   return (
     <View className="-mx-1 mb-1 px-1 py-0">
@@ -1112,23 +1129,92 @@ function AssistantStatusSection(props: {
         <Text className="font-t3-medium text-xs text-foreground opacity-80">Status</Text>
       </Pressable>
       {expanded ? (
-        hasNativeSelectableMarkdownText() ? (
-          <SelectableMarkdownText
-            markdown={props.statusText}
-            skills={props.skills}
-            textStyle={props.markdownStyles.nativeTextStyle}
-            onLinkPress={props.onLinkPress}
+        <View className="flex-col">
+          {points.map((point, index) => (
+            <StatusPointRow
+              key={index}
+              point={point}
+              expanded={expandedPoints.has(index)}
+              iconSubtleColor={props.iconSubtleColor}
+              markdownStyles={props.markdownStyles}
+              skills={props.skills}
+              onLinkPress={props.onLinkPress}
+              onToggle={() => togglePoint(index)}
+            />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function StatusPointRow(props: {
+  readonly point: string;
+  readonly expanded: boolean;
+  readonly iconSubtleColor: ColorValue;
+  readonly markdownStyles: MarkdownStyleSet;
+  readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
+  readonly onLinkPress: (href: string) => void;
+  readonly onToggle: () => void;
+}) {
+  const colorScheme = useColorScheme();
+  const pressedBackground = colorScheme === "dark" ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.035)";
+
+  return (
+    <View className="flex-col">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: props.expanded }}
+        hitSlop={4}
+        onPress={() => {
+          void Haptics.selectionAsync();
+          props.onToggle();
+        }}
+        style={({ pressed }) => ({
+          backgroundColor: pressed ? pressedBackground : "transparent",
+        })}
+        className="min-h-8 flex-row items-center gap-1.5 rounded-md px-0.5 py-0"
+      >
+        <View className="h-[18px] w-5 items-center justify-center">
+          <SymbolView
+            name={
+              props.expanded
+                ? { ios: "chevron.up", android: "keyboard_arrow_up" }
+                : { ios: "chevron.down", android: "keyboard_arrow_down" }
+            }
+            size={12}
+            tintColor={props.iconSubtleColor}
+            type="monochrome"
           />
-        ) : (
-          <Markdown
-            options={{ gfm: true }}
-            renderers={props.markdownStyles.renderers}
-            styles={props.markdownStyles.styles}
-            theme={props.markdownStyles.theme}
-          >
-            {props.statusText}
-          </Markdown>
-        )
+        </View>
+        <Text
+          className="min-w-0 flex-1 text-xs text-foreground opacity-70"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
+          {props.point}
+        </Text>
+      </Pressable>
+      {props.expanded ? (
+        <View className="pl-5">
+          {hasNativeSelectableMarkdownText() ? (
+            <SelectableMarkdownText
+              markdown={props.point}
+              skills={props.skills}
+              textStyle={props.markdownStyles.nativeTextStyle}
+              onLinkPress={props.onLinkPress}
+            />
+          ) : (
+            <Markdown
+              options={{ gfm: true }}
+              renderers={props.markdownStyles.renderers}
+              styles={props.markdownStyles.styles}
+              theme={props.markdownStyles.theme}
+            >
+              {props.point}
+            </Markdown>
+          )}
+        </View>
       ) : null}
     </View>
   );

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -330,7 +330,7 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("(empty response)");
   });
 
-  it("expands the status chip for status-only assistant messages and skips empty-response", () => {
+  it("keeps the status chip collapsed by default for status-only messages and skips empty-response", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline
         {...buildProps()}
@@ -355,9 +355,40 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Status");
-    expect(markup).toContain('aria-expanded="true"');
-    expect(markup).toContain("No background jobs running.");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).not.toContain("No background jobs running.");
     expect(markup).not.toContain("(empty response)");
+  });
+
+  it("keeps every status point hidden while the status chip is collapsed", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-assistant-multi-status",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-assistant-multi-status"),
+              role: "assistant",
+              text: "Done.",
+              statusText: "Fetching latest upstream.\nNo background jobs running.",
+              turnId: TurnId.make("turn-multi-status"),
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Done.");
+    expect(markup).toContain("Status");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).not.toContain("Fetching latest upstream.");
+    expect(markup).not.toContain("No background jobs running.");
   });
 
   it("treats only the strict list end as the live edge", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -11,6 +11,7 @@ import {
   emptyAgentPanelModel,
   formatSubagentTokenCount,
 } from "@t3tools/client-runtime/state/subagentRuntime";
+import { splitStatusPoints } from "@t3tools/client-runtime/state/status-points";
 
 const EMPTY_AGENT_PANEL_MODEL = emptyAgentPanelModel();
 const NOOP_OPEN_AGENTS = () => {};
@@ -1111,40 +1112,122 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
   );
 }
 
+function StatusSection(props: {
+  readonly statusText: string | undefined;
+  readonly isStreaming: boolean;
+  readonly markdownCwd: string | undefined;
+  readonly threadRef: ScopedThreadRef | null;
+  readonly skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+}) {
+  const points = splitStatusPoints(props.statusText);
+  const [expanded, setExpanded] = useState(false);
+  const [expandedPoints, setExpandedPoints] = useState<ReadonlySet<number>>(new Set());
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  const togglePoint = (index: number) => {
+    setExpandedPoints((previous) => {
+      const next = new Set(previous);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+      >
+        {expanded ? (
+          <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
+        ) : (
+          <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
+        )}
+        <span className="text-muted-foreground text-xs">Status</span>
+      </button>
+      {expanded ? (
+        <div className="flex flex-col">
+          {points.map((point, index) => (
+            <StatusPointRow
+              key={index}
+              point={point}
+              expanded={expandedPoints.has(index)}
+              isStreaming={props.isStreaming}
+              markdownCwd={props.markdownCwd}
+              threadRef={props.threadRef}
+              skills={props.skills}
+              onToggle={() => togglePoint(index)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusPointRow(props: {
+  readonly point: string;
+  readonly expanded: boolean;
+  readonly isStreaming: boolean;
+  readonly markdownCwd: string | undefined;
+  readonly threadRef: ScopedThreadRef | null;
+  readonly skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  readonly onToggle: () => void;
+}) {
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        aria-expanded={props.expanded}
+        onClick={props.onToggle}
+        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+      >
+        {props.expanded ? (
+          <ChevronDownIcon className="size-3 shrink-0 text-muted-foreground/65" />
+        ) : (
+          <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground/65" />
+        )}
+        <span className="min-w-0 truncate text-muted-foreground">{props.point}</span>
+      </button>
+      {props.expanded ? (
+        <div className="pl-5">
+          <ChatMarkdown
+            text={props.point}
+            cwd={props.markdownCwd}
+            threadRef={props.threadRef ?? undefined}
+            isStreaming={props.isStreaming}
+            skills={props.skills}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
-  const statusText = row.message.statusText ?? null;
-  const [statusExpanded, setStatusExpanded] = useState(!row.message.text);
   const messageText =
-    row.message.text || (row.message.streaming || statusText ? "" : "(empty response)");
+    row.message.text || (row.message.streaming || row.message.statusText ? "" : "(empty response)");
 
   return (
     <>
       <div className="relative min-w-0 px-1 py-0.5">
-        {statusText ? (
-          <button
-            type="button"
-            className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
-            aria-expanded={statusExpanded}
-            onClick={() => setStatusExpanded((value) => !value)}
-          >
-            {statusExpanded ? (
-              <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
-            ) : (
-              <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
-            )}
-            <span className="text-muted-foreground text-xs">Status</span>
-          </button>
-        ) : null}
-        {statusExpanded && statusText ? (
-          <ChatMarkdown
-            text={statusText}
-            cwd={ctx.markdownCwd}
-            threadRef={ctx.threadRef ?? undefined}
-            isStreaming={Boolean(row.message.streaming)}
-            skills={ctx.skills}
-          />
-        ) : null}
+        <StatusSection
+          statusText={row.message.statusText}
+          isStreaming={Boolean(row.message.streaming)}
+          markdownCwd={ctx.markdownCwd}
+          threadRef={ctx.threadRef}
+          skills={ctx.skills}
+        />
         <ChatMarkdown
           text={messageText}
           cwd={ctx.markdownCwd}

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -119,6 +119,10 @@
       "types": "./src/state/sourceControl.ts",
       "default": "./src/state/sourceControl.ts"
     },
+    "./state/status-points": {
+      "types": "./src/state/statusPoints.ts",
+      "default": "./src/state/statusPoints.ts"
+    },
     "./state/terminal": {
       "types": "./src/state/terminal.ts",
       "default": "./src/state/terminal.ts"

--- a/packages/client-runtime/src/state/statusPoints.test.ts
+++ b/packages/client-runtime/src/state/statusPoints.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { splitStatusPoints } from "./statusPoints.ts";
+
+describe("splitStatusPoints", () => {
+  it("returns [] for null, undefined, or empty text", () => {
+    expect(splitStatusPoints(null)).toEqual([]);
+    expect(splitStatusPoints(undefined)).toEqual([]);
+    expect(splitStatusPoints("")).toEqual([]);
+    expect(splitStatusPoints("   ")).toEqual([]);
+  });
+
+  it("keeps a single line as one point", () => {
+    expect(splitStatusPoints("Fetching latest upstream.")).toEqual(["Fetching latest upstream."]);
+  });
+
+  it("splits newline-separated status lines into one point each", () => {
+    expect(splitStatusPoints("Fetching latest upstream.\nNo background jobs running.")).toEqual([
+      "Fetching latest upstream.",
+      "No background jobs running.",
+    ]);
+  });
+
+  it("drops blank lines between points", () => {
+    expect(splitStatusPoints("First point.\n\nSecond point.\n")).toEqual([
+      "First point.",
+      "Second point.",
+    ]);
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(splitStatusPoints("First point.\r\nSecond point.\r\n")).toEqual([
+      "First point.",
+      "Second point.",
+    ]);
+  });
+
+  it("trims whitespace around each point", () => {
+    expect(splitStatusPoints("  First point.  \n\tSecond point.\t")).toEqual([
+      "First point.",
+      "Second point.",
+    ]);
+  });
+});

--- a/packages/client-runtime/src/state/statusPoints.ts
+++ b/packages/client-runtime/src/state/statusPoints.ts
@@ -1,0 +1,21 @@
+/**
+ * Split a message's accumulated status text into individual status points.
+ *
+ * Status text is built from streaming `status_text` deltas; each delta is
+ * typically one complete status line from the provider, so newlines are the
+ * point separator. Blank lines and surrounding whitespace are dropped so a
+ * collapsed list reads as one line per point.
+ */
+export function splitStatusPoints(statusText: string | null | undefined): string[] {
+  if (statusText === null || statusText === undefined) {
+    return [];
+  }
+  const points: string[] = [];
+  for (const line of statusText.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      points.push(trimmed);
+    }
+  }
+  return points;
+}


### PR DESCRIPTION
## Problem

A turn's status block streams in as one giant, unreadable wall of text, and it is auto-expanded by default — so it takes over the chat while it streams.

## Fix

Each status point now renders as its own collapsible line, and the whole status section is collapsed by default on both web and mobile. Expanding the section reveals one truncated line per point, each individually expandable to its full content. The split is presentational (`splitStatusPoints` in client-runtime) — the wire format is unchanged.
