### PR TITLE
feat(server): surface text-generation failures as thread activities

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -716,6 +716,61 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Generated title");
   });
 
+  it("surfaces a failed first-turn title generation as a failure activity", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const seededTitle = "Please investigate reconnect failures after restar...";
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-title-seed-failure"),
+        threadId: ThreadId.make("thread-1"),
+        title: seededTitle,
+      }),
+    );
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-title-gen-failure"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-title-gen-failure"),
+          role: "user",
+          text: "Please investigate reconnect failures after restarting the session.",
+          attachments: [],
+        },
+        titleSeed: seededTitle,
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return (
+        thread?.activities.some(
+          (activity) => activity.kind === "provider.text-generation.failed",
+        ) ?? false
+      );
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.text-generation.failed"),
+    ).toMatchObject({
+      tone: "error",
+      summary: "Could not name this thread",
+      payload: {
+        detail: expect.stringContaining("disabled in test harness"),
+      },
+    });
+  });
+
   it("regenerates a thread title from the current conversation", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
@@ -1031,6 +1086,58 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.title).toBe("Keep title after failure");
     expect(thread?.titleRegeneration).toBeNull();
+  });
+
+  it("surfaces a failed title regeneration as a failure activity", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-title-before-failed-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        title: "Keep title after failure",
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-before-failed-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-before-failed-regeneration"),
+          role: "user",
+          text: "Investigate the reconnect state.",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-title-failed-regeneration"),
+        threadId: ThreadId.make("thread-1"),
+        regenerateTitle: true,
+      }),
+    );
+
+    await harness.drain();
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.text-generation.failed"),
+    ).toMatchObject({
+      tone: "error",
+      summary: "Could not rename this thread",
+      payload: {
+        detail: expect.stringContaining("disabled in test harness"),
+      },
+    });
   });
 
   it("retries a failed completion and continues regenerating", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -345,7 +345,8 @@ const make = Effect.gen(function* () {
       | "provider.turn.interrupt.failed"
       | "provider.approval.respond.failed"
       | "provider.user-input.respond.failed"
-      | "provider.session.stop.failed";
+      | "provider.session.stop.failed"
+      | "provider.text-generation.failed";
     readonly summary: string;
     readonly detail: string;
     readonly turnId: TurnId | null;
@@ -800,6 +801,7 @@ const make = Effect.gen(function* () {
     readonly worktreePath: string | null;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
+    readonly createdAt: string;
   }) {
     if (!input.branch || !input.worktreePath) {
       return;
@@ -843,12 +845,27 @@ const make = Effect.gen(function* () {
       yield* vcsStatusBroadcaster.refreshStatus(cwd).pipe(Effect.ignoreCause({ log: true }));
     }).pipe(
       Effect.catchCause((cause) =>
-        Effect.logWarning("provider command reactor failed to generate or rename worktree branch", {
+        appendProviderFailureActivity({
           threadId: input.threadId,
-          cwd,
-          oldBranch,
-          cause: Cause.pretty(cause),
-        }),
+          kind: "provider.text-generation.failed",
+          summary: "Could not name this branch",
+          detail: formatFailureDetail(cause),
+          turnId: null,
+          createdAt: input.createdAt,
+        }).pipe(
+          Effect.catch(() => Effect.void),
+          Effect.andThen(
+            Effect.logWarning(
+              "provider command reactor failed to generate or rename worktree branch",
+              {
+                threadId: input.threadId,
+                cwd,
+                oldBranch,
+                cause: Cause.pretty(cause),
+              },
+            ),
+          ),
+        ),
       ),
     );
   });
@@ -860,6 +877,7 @@ const make = Effect.gen(function* () {
       readonly messageText: string;
       readonly attachments?: ReadonlyArray<ChatAttachment>;
       readonly titleSeed?: string;
+      readonly createdAt: string;
     }) {
       const attachments = input.attachments ?? [];
       yield* Effect.gen(function* () {
@@ -888,11 +906,26 @@ const make = Effect.gen(function* () {
         });
       }).pipe(
         Effect.catchCause((cause) =>
-          Effect.logWarning("provider command reactor failed to generate or rename thread title", {
+          appendProviderFailureActivity({
             threadId: input.threadId,
-            cwd: input.cwd,
-            cause: Cause.pretty(cause),
-          }),
+            kind: "provider.text-generation.failed",
+            summary: "Could not name this thread",
+            detail: formatFailureDetail(cause),
+            turnId: null,
+            createdAt: input.createdAt,
+          }).pipe(
+            Effect.catch(() => Effect.void),
+            Effect.andThen(
+              Effect.logWarning(
+                "provider command reactor failed to generate or rename thread title",
+                {
+                  threadId: input.threadId,
+                  cwd: input.cwd,
+                  cause: Cause.pretty(cause),
+                },
+              ),
+            ),
+          ),
         ),
       );
     },
@@ -1018,10 +1051,23 @@ const make = Effect.gen(function* () {
           if (Cause.hasInterruptsOnly(cause)) {
             return Effect.failCause(cause);
           }
-          return Effect.logWarning("provider command reactor failed to regenerate thread title", {
+          return appendProviderFailureActivity({
             threadId: event.payload.threadId,
-            cause: Cause.pretty(cause),
-          }).pipe(Effect.as({ _tag: "Completed", title: undefined } as const));
+            kind: "provider.text-generation.failed",
+            summary: "Could not rename this thread",
+            detail: formatFailureDetail(cause),
+            turnId: null,
+            createdAt: event.occurredAt,
+          }).pipe(
+            Effect.catch(() => Effect.void),
+            Effect.andThen(
+              Effect.logWarning("provider command reactor failed to regenerate thread title", {
+                threadId: event.payload.threadId,
+                cause: Cause.pretty(cause),
+              }),
+            ),
+            Effect.as({ _tag: "Completed", title: undefined } as const),
+          );
         }),
       );
       if (result._tag === "Superseded") {
@@ -1113,6 +1159,7 @@ const make = Effect.gen(function* () {
         threadId: event.payload.threadId,
         branch: thread.branch,
         worktreePath: thread.worktreePath,
+        createdAt: event.payload.createdAt,
         ...generationInput,
       }).pipe(Effect.forkScoped);
 
@@ -1120,6 +1167,7 @@ const make = Effect.gen(function* () {
         yield* maybeGenerateThreadTitleForFirstTurn({
           threadId: event.payload.threadId,
           cwd: generationCwd,
+          createdAt: event.payload.createdAt,
           ...generationInput,
         }).pipe(Effect.forkScoped);
       }


### PR DESCRIPTION
## Problem

Background text-generation failures (e.g. the thread-naming model out of credits) fail silently — only a server log warning, no user-visible signal. You have no idea the model failed.

## Fix

When a background text-generation op fails (thread title on first turn, title regeneration, worktree branch naming), the server appends an error-toned `provider.text-generation.failed` activity to the thread with the underlying detail. It renders in the work log on web and mobile.
