### PR TITLE
feat(server): cancel omp subagents on stop with kill fallback

### DIFF
--- a/apps/server/src/provider/omp/FakeOmpRpc.ts
+++ b/apps/server/src/provider/omp/FakeOmpRpc.ts
@@ -15,6 +15,8 @@ export class FakeOmpRpc {
   failSetModel = false;
   /** When false, `send` never answers `abort` (simulates a wedged child). */
   respondToAbort = true;
+  /** When true, `cancel_subagent` responds as an unknown command (pre-`cancel_subagent` omp). */
+  cancelSubagentUnknown = false;
   /** When set, `get_state` responses are held until this resolves (throttle-race tests). */
   getStateGate: Deferred.Deferred<void> | undefined = undefined;
   sessionFile = "/tmp/omp-session.jsonl";
@@ -172,6 +174,17 @@ export class FakeOmpRpc {
     if (command.type === "abort") {
       if (!this.respondToAbort) {
         return Effect.never;
+      }
+      return Effect.succeed({ type: "response", success: true, data: {} });
+    }
+    if (command.type === "cancel_subagent") {
+      if (this.cancelSubagentUnknown) {
+        return Effect.succeed({
+          type: "response",
+          command: "cancel_subagent",
+          success: false,
+          error: "Unknown command",
+        });
       }
       return Effect.succeed({ type: "response", success: true, data: {} });
     }

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -853,6 +853,77 @@ describe("OmpAdapter", () => {
     }),
   );
 
+  it.effect("cancels live subagents after an interrupt when omp supports cancel_subagent", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(
+          Stream.takeUntil(
+            (event) => event.type === "turn.aborted" || event.type === "session.exited",
+          ),
+        ),
+      ).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "subagent_lifecycle",
+        payload: { id: "agent-1", agent: "scout", status: "started" },
+      });
+      yield* adapter.interruptTurn(THREAD_ID);
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      NodeAssert.equal(
+        events.some(
+          (event) => event.type === "turn.aborted" && event.payload.reason === "user_abort",
+        ),
+        true,
+      );
+      NodeAssert.equal(
+        events.some((event) => event.type === "session.exited"),
+        false,
+      );
+      NodeAssert.equal(
+        fake.sent.some(
+          (command) => command.type === "cancel_subagent" && command.subagentId === "agent-1",
+        ),
+        true,
+      );
+      NodeAssert.equal(yield* adapter.hasSession(THREAD_ID), true);
+    }),
+  );
+
+  it.effect("terminates the session to stop subagents when cancel_subagent is unsupported", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      fake.cancelSubagentUnknown = true;
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(Stream.takeUntil((event) => event.type === "session.exited")),
+      ).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "subagent_lifecycle",
+        payload: { id: "agent-1", agent: "scout", status: "started" },
+      });
+      yield* adapter.interruptTurn(THREAD_ID);
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      NodeAssert.equal(
+        events.some((event) => event.type === "session.exited"),
+        true,
+      );
+      NodeAssert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }),
+  );
+
   it.effect("interruptTurn fails when the session is missing", () =>
     Effect.gen(function* () {
       const adapter = new OmpAdapter(new FakeOmpRpc(), testRandomUUID);

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -137,6 +137,8 @@ interface LiveAdapterSession {
   readonly scope: Scope.Scope;
   readonly toolCalls: Map<string, TrackedOmpToolCall>;
   readonly pendingUiRequests: Map<string, PendingExtensionUiRequest>;
+  /** Subagent ids seen via `subagent_lifecycle started` and not yet terminal. */
+  readonly liveSubagents: Set<string>;
   turnId: TurnId | undefined;
   /** Set by interruptTurn; cleared when the terminal agent_end confirms stop. */
   stopRequested: boolean;
@@ -322,6 +324,7 @@ export class OmpAdapter {
         scope,
         toolCalls: new Map(),
         pendingUiRequests: new Map(),
+        liveSubagents: new Set<string>(),
         turnId: undefined,
         stopRequested: false,
         // Negative so the first mid-turn emit is not throttled when Clock is 0 (TestClock).
@@ -901,6 +904,7 @@ export class OmpAdapter {
       ...(agentIndex === undefined ? {} : { agentIndex }),
     };
     if (payload.status === "started") {
+      session.liveSubagents.add(payload.id);
       return this.#emit({
         type: "task.started",
         threadId: session.threadId,
@@ -923,6 +927,7 @@ export class OmpAdapter {
     if (status === undefined) {
       return Effect.void;
     }
+    session.liveSubagents.delete(payload.id);
     return this.#emit({
       type: "task.completed",
       threadId: session.threadId,
@@ -1337,14 +1342,48 @@ export class OmpAdapter {
           turnId,
           payload: { reason: "user_abort" },
         });
-        return;
+      } else {
+        yield* this.#emit({
+          type: "turn.completed",
+          threadId: session.threadId,
+          turnId,
+          payload: { state: "completed" },
+        });
       }
-      yield* this.#emit({
-        type: "turn.completed",
-        threadId: session.threadId,
-        turnId,
-        payload: { state: "completed" },
-      });
+      // A user stop only settles the parent turn; background subagents (async
+      // jobs) keep running on their own decoupled run signal, so Stop must
+      // cancel them explicitly. Fall back to terminating the child when the
+      // running omp predates `cancel_subagent`.
+      if (aborted && session.liveSubagents.size > 0) {
+        yield* this.#cancelLiveSubagents(session);
+      }
+    });
+  }
+
+  #cancelLiveSubagents(session: LiveAdapterSession): Effect.Effect<void> {
+    const ids = Array.from(session.liveSubagents);
+    if (ids.length === 0) {
+      return Effect.void;
+    }
+    return Effect.gen({ self: this }, function* () {
+      for (const subagentId of ids) {
+        const outcome = yield* Effect.exit(
+          this.#send(session.threadId, { type: "cancel_subagent", subagentId }).pipe(
+            Effect.timeout(OMP_ABORT_ACK_TIMEOUT),
+          ),
+        );
+        // `cancel_subagent` acknowledges with a response; a `success: false`
+        // response means the command is unknown (pre-`cancel_subagent` omp) or
+        // the cancel failed. An effect-level failure means the child died. In
+        // every non-success case the only way to actually stop the subagents
+        // is to terminate the child.
+        const cancelled =
+          Exit.isSuccess(outcome) && isRecord(outcome.value) && outcome.value.success === true;
+        if (!cancelled) {
+          yield* this.#onSessionTransportEnded(session);
+          return;
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Problem

Stopping the main agent leaves its background subagents running to completion — omp's `abort` is turn-level by design, and subagents run on their own decoupled signal. There is no way to stop them without destroying the session.

## Fix

On Stop, the omp adapter now sends `cancel_subagent` per live subagent (tracked via `subagent_lifecycle`). When the running omp doesn't support the command (checked at runtime), it falls back to terminating the omp child, which stops the subagents. The fallback drops away once a released omp with `cancel_subagent` ships — tracked in #32.
