### PR TITLE
docs: require a human-authored explanation in PR bodies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Explain exactly what changed.
 
 Explain exactly why the change should exist.
 
+The PR body must include at least one sentence written by you, in your own words, explaining what changed and why. A generated summary, pasted agent transcript, or checklist alone does not satisfy this — if an agent produced the change, review every changed file yourself and write the explanation.
+
 Do not mix unrelated fixes together.
 
 If the PR makes anything resembling a UI change, include clear before/after images.


### PR DESCRIPTION
## Problem

PR bodies can be entirely agent-generated, with no human-verified explanation of what changed or why.

## Fix

CONTRIBUTING.md now requires every PR body to include at least one sentence written by the author in their own words, and to review every changed file when an agent produced the change. Mirrors oh-my-pi's rule so remote/agent-driven contributions carry a human-owned explanation.

Model: opencode-go/deepseek-v4-flash via omp.
