### PR TITLE
docs: drop the model-line requirement from PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Bypass for a single command: `VP_GIT_HOOKS=0 git commit` / `VP_GIT_HOOKS=0 git p
 
 - Never make a PR unless the developer explicitly asks you to do so.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
-- Body: the problem in a sentence or two, then how you fixed it. Include at least one sentence written by you, in your own words, explaining the change (see CONTRIBUTING.md).
+- Body: the problem in a sentence or two, then how you fixed it.
 - **Rebase onto latest main before opening.** Stale branches conflict and burn a review round.
 - Motion or timing needs a short video.
 - One concern per PR. If the description says "also", split it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Bypass for a single command: `VP_GIT_HOOKS=0 git commit` / `VP_GIT_HOOKS=0 git p
 
 - Never make a PR unless the developer explicitly asks you to do so.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
-- Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
+- Body: the problem in a sentence or two, then how you fixed it. Include at least one sentence written by you, in your own words, explaining the change (see CONTRIBUTING.md).
 - **Rebase onto latest main before opening.** Stale branches conflict and burn a review round.
 - Motion or timing needs a short video.
 - One concern per PR. If the description says "also", split it.


### PR DESCRIPTION
## Problem

AGENTS.md instructed PR authors to end the body with "the model and harness that did the work" — a generated line that doesn't tell a reviewer what changed or why.

## Fix

Drop that requirement. The PR-body rule in AGENTS.md is now just: the problem in a sentence or two, then how you fixed it. The human-authored-sentence requirement lives in CONTRIBUTING.md (see #37), not AGENTS.md.
