### PR TITLE
Docs/pr template update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,8 @@
 <!--
 ⚠️ READ BEFORE OPENING ⚠️
 
-We are not actively accepting contributions right now.
-
-You can still open a PR, but please do so knowing there is a high chance
-we may close it without merging it, or never review it.
-
 - Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
 - New features will most likely just annoy us.
-- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
 -->
 
 ## What Changed

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Pivot is a fork of T3 Code: an agent harness control surface (desktop, web, and 
 
 <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/dd8d5880-b279-44c9-947b-332755e81ccf" />
 
-
-
 CLI package: [`pivot-cli`](https://www.npmjs.com/package/pivot-cli) (bin: `pivot`). Desktop builds publish from [this repo’s Releases](https://github.com/13kparkin/Pivot/releases).
 
 ## What changed from T3 Code


### PR DESCRIPTION
## What Changed

- `.github/pull_request_template.md`: removed the "not actively accepting contributions" notice and the "banned from the repo" threat; kept the useful guidance — small focused PRs preferred, bug fixes most likely to be merged.
- `README.md`: dropped stray blank lines flagged by the repo formatter (pre-push gate).

## Why

The template told contributors their PRs would likely be closed or never reviewed, but we do accept PRs. The discouragement is gone; the practical guidance stays.

## UI Changes

N/A — no UI change.