### PR TITLE
feat(web): polish project rows and card nesting in the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Pivot is a fork of T3 Code: an agent harness control surface (desktop, web, and 
 
 <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/dd8d5880-b279-44c9-947b-332755e81ccf" />
 
-
-
 CLI package: [`pivot-cli`](https://www.npmjs.com/package/pivot-cli) (bin: `pivot`). Desktop builds publish from [this repo’s Releases](https://github.com/13kparkin/Pivot/releases).
 
 ## What changed from T3 Code

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1252,7 +1252,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       }
       {...(sortable?.listeners ?? {})}
       className={cn(
-        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]",
+        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_74px]",
         sortable?.isDragging && "z-20 opacity-80",
       )}
     >
@@ -1272,7 +1272,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
+          <div className="relative z-10 h-[4.375rem] px-[var(--sidebar-row-content-inset)] py-1">
             <div className="flex h-5 min-w-0 items-center gap-1.5">
               <ProjectFavicon
                 environmentId={thread.environmentId}

--- a/apps/web/src/components/capabilities/CapabilitiesSidebarNav.tsx
+++ b/apps/web/src/components/capabilities/CapabilitiesSidebarNav.tsx
@@ -15,6 +15,7 @@ import {
   ScrollTextIcon,
   SearchIcon,
   Settings2Icon,
+  Trash2Icon,
   XIcon,
 } from "lucide-react";
 import { useCanGoBack, useNavigate, useSearch } from "@tanstack/react-router";
@@ -31,6 +32,20 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "../ui/sidebar";
+import {
+  isAtomCommandInterrupted,
+  mapAtomCommandResult,
+  settlePromise,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { readLocalApi } from "../../localApi";
+import { useThreadShells } from "../../state/entities";
+import { projectEnvironment } from "../../state/projects";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { stackedThreadToast, toastManager } from "../ui/toast";
 import { useSettingsProjectGroups } from "../settings/ProjectSettingsPanel";
 import {
   CAPABILITIES_SECTION_LABELS,
@@ -61,6 +76,10 @@ export const CAPABILITIES_NAV_ITEMS: ReadonlyArray<{
 function CapabilitiesSectionIcon({ to }: { to: CapabilitiesPath }) {
   const Icon = CAPABILITIES_SECTION_ICONS[to];
   return <Icon className="mt-0.5 size-3.5 shrink-0 text-sidebar-muted-foreground/60" />;
+}
+
+function memberKey(member: { environmentId: string; id: string }): string {
+  return `${member.environmentId}:${member.id}`;
 }
 
 export function CapabilitiesSidebarNav({ pathname }: { pathname: string }) {
@@ -165,6 +184,87 @@ export function CapabilitiesSidebarNav({ pathname }: { pathname: string }) {
     }
     void navigate({ to: "/" });
   }, [canGoBack, isMobile, navigate, setOpenMobile]);
+
+  // Project removal from the project-scoped capabilities nav. Mirrors the
+  // settings-page flow: confirm (naming thread loss), delete every grouped
+  // member, clear drafts, then drop the scope back to global capabilities.
+  const threads = useThreadShells();
+  const deleteProject = useAtomCommand(projectEnvironment.delete, { reportFailure: false });
+  const handleRemoveProject = useCallback(async () => {
+    if (projectGroup === null) return;
+    const api = readLocalApi();
+    if (!api) return;
+
+    const memberKeys = new Set(projectGroup.memberProjects.map(memberKey));
+    const projectThreads = threads.filter((thread) =>
+      memberKeys.has(`${thread.environmentId}:${thread.projectId}`),
+    );
+    const singleMember =
+      projectGroup.memberProjects.length === 1 ? projectGroup.memberProjects[0]! : null;
+    const targetLabel = singleMember?.title ?? projectGroup.displayName;
+    const confirmed = await settlePromise(() =>
+      api.dialogs.confirm(
+        [
+          projectThreads.length > 0
+            ? `Remove project "${targetLabel}" and delete its ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}?`
+            : `Remove project "${targetLabel}"?`,
+          ...(singleMember
+            ? [
+                `Path: ${singleMember.workspaceRoot}`,
+                ...(singleMember.environmentLabel
+                  ? [`Environment: ${singleMember.environmentLabel}`]
+                  : []),
+              ]
+            : [`This removes ${projectGroup.memberProjects.length} grouped project entries.`]),
+          ...(projectThreads.length > 0
+            ? ["This permanently clears conversation history for those threads."]
+            : []),
+          "This removes only the project entries, not the files on disk.",
+          "This action cannot be undone.",
+        ].join("\n"),
+        { variant: "destructive" },
+      ),
+    );
+    if (confirmed._tag === "Failure" || !confirmed.value) return;
+
+    const draftStore = useComposerDraftStore.getState();
+    for (const member of projectGroup.memberProjects) {
+      const memberThreads = projectThreads.filter(
+        (thread) => thread.environmentId === member.environmentId && thread.projectId === member.id,
+      );
+      const result = mapAtomCommandResult(
+        await deleteProject({
+          environmentId: member.environmentId,
+          input: {
+            projectId: member.id,
+            ...(memberThreads.length > 0 ? { force: true } : {}),
+          },
+        }),
+        () => undefined,
+      );
+      if (result._tag === "Failure") {
+        if (isAtomCommandInterrupted(result)) return;
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: `Failed to remove "${member.title}"`,
+            description: error instanceof Error ? error.message : "Could not remove the project.",
+          }),
+        );
+        return;
+      }
+      const projectRef = scopeProjectRef(member.environmentId, member.id);
+      const projectDraftThread = draftStore.getDraftThreadByProjectRef(projectRef);
+      if (projectDraftThread) {
+        draftStore.clearDraftThread(projectDraftThread.draftId);
+      }
+      draftStore.clearProjectDraftThreadId(projectRef);
+    }
+
+    // The scoped project is gone; drop the scope and stay in capabilities.
+    void navigate({ to: "/capabilities", search: {}, replace: true });
+  }, [deleteProject, navigate, projectGroup, threads]);
   const handleSearchKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
       if (event.key === "Escape" && isSearching) {
@@ -310,6 +410,18 @@ export function CapabilitiesSidebarNav({ pathname }: { pathname: string }) {
           </div>
         ) : null}
         <SidebarMenu className="min-w-0 flex-1">
+          {projectGroup !== null ? (
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                type="button"
+                className="text-destructive hover:bg-destructive/8 hover:text-destructive"
+                onClick={() => void handleRemoveProject()}
+              >
+                <Trash2Icon />
+                <span>Remove project</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ) : null}
           <SidebarMenuItem>
             <SidebarMenuButton onClick={handleBackClick}>
               <ArrowLeftIcon />

--- a/apps/web/src/components/sidebar/SidebarProjectsSection.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarProjectsSection.test.tsx
@@ -120,6 +120,7 @@ describe("SidebarProjectsSection", () => {
     });
 
     expect(markup).toContain('data-testid="sidebar-project-threads-project-a"');
+    expect(markup).toContain('class="flex flex-col gap-px ps-6"');
     expect(markup).toContain('data-testid="row-pinned-t-pinned"');
     expect(markup).toContain('data-testid="row-active-t-active"');
     expect(markup.indexOf("row-pinned-t-pinned")).toBeLessThan(

--- a/apps/web/src/components/sidebar/SidebarProjectsSection.tsx
+++ b/apps/web/src/components/sidebar/SidebarProjectsSection.tsx
@@ -121,7 +121,7 @@ export function SidebarProjectsSection(props: SidebarProjectsSectionProps) {
               </div>
               {expanded ? (
                 <ul
-                  className="flex flex-col gap-px"
+                  className="flex flex-col gap-px ps-6"
                   data-testid={`sidebar-project-threads-${group.projectKey}`}
                 >
                   {pinned.map((thread) => {

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -18,8 +18,10 @@ their pinned threads keep the default newest-first order below the ones you have
 The **Projects** section sits below the search and filter controls. Each row
 shows the project's icon, name, and environment badge; the gear on the row
 opens that project's omp capabilities (settings, skills, and rules scoped to
-the project's `.omp` folder). The project filter above the list narrows which
-projects — and their nested threads — appear.
+the project's `.omp` folder). The capabilities sidebar there also offers
+**Remove project**, which deletes the project's entries — and their
+conversation history — without touching the files on disk. The project filter
+above the list narrows which projects — and their nested threads — appear.
 
 Drafts you are composing stay at the top of the sidebar, above the projects.
 


### PR DESCRIPTION
## What Changed

- Thread cards nested under a project in the sidebar are indented past the project's chevron, so they read as belonging to that project rather than a flat list.
- Thread cards are slightly shorter (tighter vertical padding), so more threads fit per view.
- The project-scoped capabilities nav — opened from a project row's gear — gains a **Remove project** action. It mirrors the Settings flow: destructive confirm naming thread loss, per-checkout deletion, composer draft cleanup, then returns to global capabilities.

## Why

The per-project sidebar section rendered as a flat list: cards sat flush with the project row and taller than needed. Removing a project required hunting through Settings; the project-scoped capabilities view is where that management belongs.

## UI Changes

N/A
