### PR TITLE
feat(web): toast on mid-turn agent failures

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -188,6 +188,7 @@ import {
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
+import { useThreadFailureToasts } from "../hooks/useThreadFailureToasts";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
@@ -1208,6 +1209,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
+  useThreadFailureToasts(routeKind === "server" ? routeThreadRef : null);
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
   });

--- a/apps/web/src/hooks/useThreadFailureToasts.ts
+++ b/apps/web/src/hooks/useThreadFailureToasts.ts
@@ -1,0 +1,55 @@
+import { type ScopedThreadRef } from "@t3tools/contracts";
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
+import { useEffect } from "react";
+
+import { stackedThreadToast, toastManager } from "../components/ui/toast";
+import {
+  failureActivityDetail,
+  observeThreadFailureActivities,
+} from "../lib/threadFailureNotifications";
+import { useThreadActivities, useThreadStatus } from "../state/entities";
+
+/**
+ * Per-session memory of accounted failure activities, keyed by thread. Lives
+ * at module scope so switching threads (or remounting the chat view) never
+ * re-toasts a failure that already surfaced. Cleared on page reload, which is
+ * correct: first observation of a thread re-seeds with its current activities.
+ */
+const seenFailureActivitiesByThread = new Map<string, Set<string>>();
+
+/**
+ * Surfaces genuine failures that happen while a thread is working (auto
+ * naming, runtime errors, checkpoint capture/revert, provider failures,
+ * setup-script launch, ...) as a top-right error toast, the same channel the
+ * rest of the app uses for action failures.
+ *
+ * Only the routed thread's live detail stream is watched: background threads
+ * have no live detail subscription in the web app, and forcing one would
+ * multiply renderer-heap and server load.
+ */
+export function useThreadFailureToasts(ref: ScopedThreadRef | null): void {
+  const activities = useThreadActivities(ref);
+  const status = useThreadStatus(ref);
+
+  useEffect(() => {
+    if (ref === null) {
+      return;
+    }
+    const newFailures = observeThreadFailureActivities(
+      scopedThreadKey(ref),
+      activities,
+      status === "live",
+      seenFailureActivitiesByThread,
+    );
+    for (const activity of newFailures) {
+      const description = failureActivityDetail(activity);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: activity.summary,
+          ...(description !== undefined ? { description } : {}),
+        }),
+      );
+    }
+  }, [activities, ref, status]);
+}

--- a/apps/web/src/lib/threadFailureNotifications.test.ts
+++ b/apps/web/src/lib/threadFailureNotifications.test.ts
@@ -1,0 +1,177 @@
+import { EventId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  failureActivityDetail,
+  isThreadFailureActivityToastable,
+  observeThreadFailureActivities,
+} from "./threadFailureNotifications";
+
+let nextActivityId = 0;
+
+function activity(
+  overrides: Partial<OrchestrationThreadActivity> = {},
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(`failure-${nextActivityId++}`),
+    createdAt: "2026-08-16T12:00:00.000Z",
+    kind: "provider.text-generation.failed",
+    summary: "Could not name this thread",
+    tone: "error",
+    payload: {},
+    turnId: null,
+    ...overrides,
+  };
+}
+
+describe("isThreadFailureActivityToastable", () => {
+  it("accepts genuine error-toned failures", () => {
+    expect(isThreadFailureActivityToastable(activity())).toBe(true);
+    expect(isThreadFailureActivityToastable(activity({ kind: "runtime.error" }))).toBe(true);
+    expect(isThreadFailureActivityToastable(activity({ kind: "checkpoint.capture.failed" }))).toBe(
+      true,
+    );
+    expect(isThreadFailureActivityToastable(activity({ kind: "checkpoint.revert.failed" }))).toBe(
+      true,
+    );
+    expect(isThreadFailureActivityToastable(activity({ kind: "provider.turn.start.failed" }))).toBe(
+      true,
+    );
+    expect(isThreadFailureActivityToastable(activity({ kind: "setup-script.failed" }))).toBe(true);
+  });
+
+  it("rejects non-error tones", () => {
+    expect(isThreadFailureActivityToastable(activity({ tone: "info" }))).toBe(false);
+    expect(isThreadFailureActivityToastable(activity({ tone: "tool" }))).toBe(false);
+    expect(isThreadFailureActivityToastable(activity({ tone: "approval" }))).toBe(false);
+  });
+
+  it("rejects intentional or advisory error-toned activities", () => {
+    expect(isThreadFailureActivityToastable(activity({ kind: "tool.denied" }))).toBe(false);
+    expect(isThreadFailureActivityToastable(activity({ kind: "advisor.comment" }))).toBe(false);
+  });
+
+  it("rejects stale pending-request bookkeeping failures", () => {
+    const staleDetails = [
+      "Stale pending approval request: req-1",
+      "Unknown pending permission request: req-1",
+      "Unknown pending user input request: req-1",
+      "Stale pending user-input request: req-1",
+    ];
+    for (const detail of staleDetails) {
+      expect(
+        isThreadFailureActivityToastable(
+          activity({
+            kind: "provider.approval.respond.failed",
+            payload: { detail },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        isThreadFailureActivityToastable(
+          activity({
+            kind: "provider.user-input.respond.failed",
+            payload: { detail },
+          }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts real pending-response failures", () => {
+    expect(
+      isThreadFailureActivityToastable(
+        activity({
+          kind: "provider.approval.respond.failed",
+          payload: { detail: "Provider process exited" },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("failureActivityDetail", () => {
+  it("prefers the payload detail over the message", () => {
+    expect(
+      failureActivityDetail(
+        activity({ payload: { detail: "Model not found: openai/gpt-5", message: "nope" } }),
+      ),
+    ).toBe("Model not found: openai/gpt-5");
+  });
+
+  it("falls back to the payload message", () => {
+    expect(failureActivityDetail(activity({ payload: { message: "boom" } }))).toBe("boom");
+  });
+
+  it("returns undefined when the payload has no failure body", () => {
+    expect(failureActivityDetail(activity({ payload: {} }))).toBeUndefined();
+  });
+});
+
+describe("observeThreadFailureActivities", () => {
+  const tracker = (): Map<string, Set<string>> => new Map();
+
+  it("records pre-existing failures seen before the stream is live", () => {
+    const seenByThread = tracker();
+    const oldFailure = activity();
+    expect(observeThreadFailureActivities("thread-1", [oldFailure], false, seenByThread)).toEqual(
+      [],
+    );
+    expect(observeThreadFailureActivities("thread-1", [oldFailure], true, seenByThread)).toEqual(
+      [],
+    );
+  });
+
+  it("toasts a new failure exactly once while live", () => {
+    const seenByThread = tracker();
+    observeThreadFailureActivities("thread-1", [], false, seenByThread);
+    const fresh = activity();
+    const first = observeThreadFailureActivities("thread-1", [fresh], true, seenByThread);
+    expect(first.map((entry) => entry.id)).toEqual([fresh.id]);
+    expect(observeThreadFailureActivities("thread-1", [fresh], true, seenByThread)).toEqual([]);
+  });
+
+  it("does not toast failures recorded while not live when the stream goes live", () => {
+    const seenByThread = tracker();
+    observeThreadFailureActivities("thread-1", [], false, seenByThread);
+    const duringSync = activity();
+    expect(observeThreadFailureActivities("thread-1", [duringSync], false, seenByThread)).toEqual(
+      [],
+    );
+    expect(observeThreadFailureActivities("thread-1", [duringSync], true, seenByThread)).toEqual(
+      [],
+    );
+  });
+
+  it("toasts pre-existing failures once on servers without completion markers", () => {
+    // Legacy edge: the initial snapshot is applied directly as live.
+    const seenByThread = tracker();
+    const oldFailure = activity();
+    expect(observeThreadFailureActivities("thread-1", [oldFailure], true, seenByThread)).toEqual([
+      oldFailure,
+    ]);
+    expect(observeThreadFailureActivities("thread-1", [oldFailure], true, seenByThread)).toEqual(
+      [],
+    );
+  });
+
+  it("ignores non-toastable activities entirely", () => {
+    const seenByThread = tracker();
+    const denied = activity({ kind: "tool.denied" });
+    observeThreadFailureActivities("thread-1", [denied], false, seenByThread);
+    expect(observeThreadFailureActivities("thread-1", [denied], true, seenByThread)).toEqual([]);
+  });
+
+  it("keeps per-thread state independent", () => {
+    const seenByThread = tracker();
+    observeThreadFailureActivities("thread-1", [], false, seenByThread);
+    const preExisting = activity();
+    observeThreadFailureActivities("thread-2", [preExisting], false, seenByThread);
+    const fresh = activity();
+    expect(
+      observeThreadFailureActivities("thread-2", [preExisting, fresh], true, seenByThread).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual([fresh.id]);
+  });
+});

--- a/apps/web/src/lib/threadFailureNotifications.ts
+++ b/apps/web/src/lib/threadFailureNotifications.ts
@@ -1,0 +1,97 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import { isStalePendingRequestFailureDetail } from "../session-logic";
+
+/**
+ * Error-toned activity kinds that are not real failures, so they must never
+ * produce a failure toast:
+ * - `tool.denied` is an intentional user denial of a tool request.
+ * - `advisor.comment` is review feedback (already tinted destructively for
+ *   blockers in the timeline), not a failure of the agent's work.
+ */
+const NON_FAILURE_ERROR_KINDS: Record<string, true> = {
+  "tool.denied": true,
+  "advisor.comment": true,
+};
+
+const PENDING_RESPONSE_FAILURE_KINDS: Record<string, true> = {
+  "provider.approval.respond.failed": true,
+  "provider.user-input.respond.failed": true,
+};
+
+/** Reads the human-readable failure body from an activity's payload. */
+export function failureActivityDetail(activity: OrchestrationThreadActivity): string | undefined {
+  const payload = activity.payload;
+  if (payload === null || typeof payload !== "object") {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  if (typeof record.detail === "string" && record.detail.length > 0) {
+    return record.detail;
+  }
+  if (typeof record.message === "string" && record.message.length > 0) {
+    return record.message;
+  }
+  return undefined;
+}
+
+/**
+ * True when an error-toned activity represents a genuine failure worth
+ * surfacing to the user (naming, runtime, checkpoint, provider, setup-script,
+ * ...). Bookkeeping failures for pending requests the server has already
+ * forgotten (stale/unknown pending approval or user-input) stay silent: they
+ * are cleanup artifacts after a restart, not actionable failures.
+ */
+export function isThreadFailureActivityToastable(activity: OrchestrationThreadActivity): boolean {
+  if (activity.tone !== "error") {
+    return false;
+  }
+  if (NON_FAILURE_ERROR_KINDS[activity.kind] === true) {
+    return false;
+  }
+  if (PENDING_RESPONSE_FAILURE_KINDS[activity.kind] === true) {
+    return !isStalePendingRequestFailureDetail(failureActivityDetail(activity));
+  }
+  return true;
+}
+
+/**
+ * Accounts for a thread's activity list and returns the failure activities
+ * that are genuinely new and should be toasted.
+ *
+ * History never toasts: hydration and reconnect replays arrive while the
+ * detail stream is not yet `live`, so those ids are recorded silently. Only
+ * ids first observed while `live` (fresh failures streaming in mid-turn) are
+ * returned, and each id toasts at most once per session.
+ *
+ * Edge: on servers without resume-completion markers the initial snapshot is
+ * applied directly as live, so a failure already on the thread toasts once on
+ * open. The user is looking at that thread and the row renders in the
+ * timeline, so this only adds a redundant toast.
+ */
+export function observeThreadFailureActivities(
+  threadKey: string,
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  live: boolean,
+  seenByThread: Map<string, Set<string>>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  let seen = seenByThread.get(threadKey);
+  if (seen === undefined) {
+    seen = new Set<string>();
+    seenByThread.set(threadKey, seen);
+  }
+  const toToast: OrchestrationThreadActivity[] = [];
+  for (const activity of activities) {
+    if (!isThreadFailureActivityToastable(activity)) {
+      continue;
+    }
+    if (seen.has(activity.id)) {
+      continue;
+    }
+    seen.add(activity.id);
+    if (live) {
+      toToast.push(activity);
+    }
+  }
+  return toToast;
+}

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -359,7 +359,7 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
   }
 }
 
-function isStalePendingRequestFailureDetail(detail: string | undefined): boolean {
+export function isStalePendingRequestFailureDetail(detail: string | undefined): boolean {
   const normalized = detail?.toLowerCase();
   if (!normalized) {
     return false;


### PR DESCRIPTION
## What Changed

- Failures that stream in while a turn is running — auto thread/branch naming, runtime errors, checkpoint capture/revert, provider failures, setup-script launch — now surface as a top-right error toast, the same channel as existing action-failure toasts.
- New `useThreadFailureToasts` hook (mounted for the routed thread in `ChatView`) plus `threadFailureNotifications` logic: only genuine error-toned activities toast; `tool.denied`, `advisor.comment`, and stale pending-request cleanup failures stay silent; each failure toasts once per session; thread history and reconnect replays never toast.
- `session-logic.ts` exports `isStalePendingRequestFailureDetail` for reuse.

## Why

Failures like auto-naming a thread failing ("Model not found") were only recorded as a muted activity row in the timeline, so users were never notified. Surfacing them through the existing toast channel.

## UI Changes

Error toast appears top-right when a mid-turn failure activity streams in while the thread is open, once per failure per session.
