### PR TITLE
feat(shared): name new worktree branches with the pivot prefix

### DIFF
--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -71,6 +71,12 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
   });
 
+  it("still recognizes pre-fork t3code temporary worktree refs", () => {
+    expect(isTemporaryWorktreeBranch("t3code/deadbeef")).toBe(true);
+    expect(isTemporaryWorktreeBranch("t3code/f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12")).toBe(true);
+    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
+  });
+
   it("normalizes a UUID-shaped random callback to the canonical 8-hex form", () => {
     expect(buildTemporaryWorktreeBranchName(() => "f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12")).toBe(
       `${WORKTREE_BRANCH_PREFIX}/f4ae4e0e`,

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -10,13 +10,15 @@ import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
-export const WORKTREE_BRANCH_PREFIX = "t3code";
-// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
+export const WORKTREE_BRANCH_PREFIX = "pivot";
+// Canonical form is `<prefix>/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
 // via Crypto.randomUUID() (always RFC 4122 v4), so the matcher also accepts exactly
 // that shape — version nibble `4`, variant nibble `[89ab]` — to keep those threads
 // eligible for branch regeneration without loosening beyond what was ever generated.
+// `t3code` is the pre-fork prefix; it is no longer generated but still recognized so
+// threads created before the T3 Code → Pivot rename keep working.
 const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
-  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$`,
+  `^(?:${WORKTREE_BRANCH_PREFIX}|t3code)\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$`,
 );
 
 /**


### PR DESCRIPTION
## What Changed

- New temporary worktree branches created for agent threads now use the `pivot/` prefix (e.g. `pivot/a1b2c3d4`) instead of the pre-fork `t3code/` branding (`packages/shared/src/git.ts`).
- The temporary-branch matcher still recognizes legacy `t3code/<8-hex>` and `t3code/<uuid>` branches, so threads created before the rename keep their branch-regeneration and temp-branch UI behavior.

## Why

Pivot forked from T3 Code, but worktree branch names still carried the `t3code/` branding. This renames the prefix to match Pivot without breaking threads that already have `t3code/` branches.

## UI Changes

N/A
