### PR TITLE
feat(omp): spawn sessions in rpc-ui mode so the ask tool works (#40)

### DIFF
--- a/apps/server/src/provider/Drivers/OmpDriver.test.ts
+++ b/apps/server/src/provider/Drivers/OmpDriver.test.ts
@@ -101,7 +101,8 @@ function makeFakeOmpSpawner(sessionFile: string, agentDir = "/tmp/t3-omp-agent")
       };
       spawns.push(spawn);
 
-      // `omp --version` probes and `omp config path` are plain CLI, not RPC.
+      // `omp --version` probes, `omp --help` capability probes, and
+      // `omp config path` are plain CLI, not RPC.
       if (spawned.args.includes("--version")) {
         return ChildProcessSpawner.makeHandle({
           pid: ChildProcessSpawner.ProcessId(spawns.length),
@@ -111,6 +112,22 @@ function makeFakeOmpSpawner(sessionFile: string, agentDir = "/tmp/t3-omp-agent")
           unref: Effect.succeed(Effect.void),
           stdin: Sink.drain,
           stdout: Stream.make(encoder.encode("omp/17.3.0\n")),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        });
+      }
+
+      if (spawned.args.includes("--help")) {
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(spawns.length),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.make(encoder.encode("Usage: omp [options] --mode text|json|rpc|rpc-ui\n")),
           stderr: Stream.empty,
           all: Stream.empty,
           getInputFd: () => Sink.drain,
@@ -270,7 +287,11 @@ describe("OmpDriver", () => {
       NodeAssert.equal(fake.spawns.length, spawnsBeforeSession + 1);
       const sessionSpawn = fake.spawns[fake.spawns.length - 1];
       NodeAssert.equal(sessionSpawn?.command, binaryPath);
-      NodeAssert.ok(sessionSpawn?.args.includes("--mode"));
+      const sessionModeIndex = sessionSpawn?.args.indexOf("--mode") ?? -1;
+      NodeAssert.equal(
+        sessionModeIndex >= 0 ? sessionSpawn?.args[sessionModeIndex + 1] : undefined,
+        "rpc-ui",
+      );
       NodeAssert.equal(session.resumeCursor, "/tmp/omp-session.jsonl");
     }).pipe(Effect.scoped),
   );

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -1164,6 +1164,141 @@ describe("OmpAdapter", () => {
     }),
   );
 
+  it.effect("completes a turn when the agent asks a select mid-turn and the user answers", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      // Wait for the pending ask to register before answering (the frame
+      // stream processes the select on its own fiber).
+      const requestedFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "user-input.requested"),
+        ),
+      ).pipe(Effect.forkChild);
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "extension_ui_request",
+        id: "ask-select-1",
+        method: "select",
+        title: "Which storage backend?",
+        options: ["local", "s3"],
+      });
+      const requestedEvents = yield* Fiber.join(requestedFiber);
+      const requested = requestedEvents.find(
+        (event) => event.type === "user-input.requested" && event.requestId === "ask-select-1",
+      );
+      NodeAssert.ok(requested);
+      NodeAssert.deepEqual(
+        requested.payload.questions[0]?.options.map((option) => option.label),
+        ["local", "s3"],
+      );
+
+      const completedFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      yield* adapter.respondToUserInput(THREAD_ID, ApprovalRequestId.make("ask-select-1"), {
+        choice: "s3",
+      });
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(completedFiber);
+      NodeAssert.deepEqual(
+        fake.sent.find((command) => command.type === "extension_ui_response"),
+        { type: "extension_ui_response", id: "ask-select-1", value: "s3" },
+      );
+      NodeAssert.equal(
+        events.some(
+          (event) => event.type === "user-input.resolved" && event.requestId === "ask-select-1",
+        ),
+        true,
+      );
+      NodeAssert.equal(events.filter((event) => event.type === "turn.completed").length, 1);
+    }),
+  );
+
+  it.effect(
+    "resolves a pending ask with empty answers when omp cancels it, and the turn completes",
+    () =>
+      Effect.gen(function* () {
+        const fake = new FakeOmpRpc();
+        const adapter = new OmpAdapter(fake, testRandomUUID);
+        const requestedFiber = yield* Stream.runCollect(
+          adapter.streamEvents.pipe(
+            Stream.takeUntil((event) => event.type === "user-input.requested"),
+          ),
+        ).pipe(Effect.forkChild);
+        yield* adapter.startSession(startInput);
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+        yield* fake.offer(THREAD_ID, {
+          type: "extension_ui_request",
+          id: "ask-select-2",
+          method: "select",
+          title: "Which storage backend?",
+          options: ["local", "s3"],
+        });
+        yield* Fiber.join(requestedFiber);
+        yield* fake.offer(THREAD_ID, {
+          type: "extension_ui_request",
+          method: "cancel",
+          targetId: "ask-select-2",
+        });
+        const eventsFiber = yield* collectUntilTurnCompleted(adapter.streamEvents).pipe(
+          Effect.forkChild,
+        );
+        yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+        const events = yield* Fiber.join(eventsFiber);
+        const resolved = events.find(
+          (event) => event.type === "user-input.resolved" && event.requestId === "ask-select-2",
+        );
+        NodeAssert.ok(resolved);
+        NodeAssert.deepEqual(resolved.payload.answers, {});
+        NodeAssert.equal(
+          events.some((event) => event.type === "turn.completed"),
+          true,
+        );
+        // A cancelled ask must not be answered.
+        NodeAssert.equal(
+          fake.sent.some((command) => command.type === "extension_ui_response"),
+          false,
+        );
+      }),
+  );
+
+  it.effect("interruptTurn during a pending ask writes abort and settles without hanging", () =>
+    Effect.gen(function* () {
+      const fake = new FakeOmpRpc();
+      const adapter = new OmpAdapter(fake, testRandomUUID);
+      const requestedFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "user-input.requested"),
+        ),
+      ).pipe(Effect.forkChild);
+      yield* adapter.startSession(startInput);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "hi" });
+      yield* fake.offer(THREAD_ID, {
+        type: "extension_ui_request",
+        id: "ask-select-3",
+        method: "select",
+        title: "Which storage backend?",
+        options: ["local", "s3"],
+      });
+      yield* Fiber.join(requestedFiber);
+      yield* adapter.interruptTurn(THREAD_ID);
+      NodeAssert.equal(
+        fake.sent.some((command) => command.type === "abort"),
+        true,
+      );
+      const eventsFiber = yield* Stream.runCollect(
+        adapter.streamEvents.pipe(Stream.takeUntil((event) => event.type === "turn.aborted")),
+      ).pipe(Effect.forkChild);
+      yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
+      const events = yield* Fiber.join(eventsFiber);
+      const aborted = events.find((event) => event.type === "turn.aborted");
+      NodeAssert.ok(aborted);
+      NodeAssert.equal(aborted.payload.reason, "user_abort");
+    }),
+  );
+
   it.effect("respondToRequest without a pending confirm fails clearly", () =>
     Effect.gen(function* () {
       const adapter = new OmpAdapter(new FakeOmpRpc(), testRandomUUID);

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -1185,10 +1185,9 @@ describe("OmpAdapter", () => {
         options: ["local", "s3"],
       });
       const requestedEvents = yield* Fiber.join(requestedFiber);
-      const requested = requestedEvents.find(
-        (event) => event.type === "user-input.requested" && event.requestId === "ask-select-1",
-      );
+      const requested = requestedEvents.find((event) => event.type === "user-input.requested");
       NodeAssert.ok(requested);
+      NodeAssert.equal(requested.requestId, "ask-select-1");
       NodeAssert.deepEqual(
         requested.payload.questions[0]?.options.map((option) => option.label),
         ["local", "s3"],
@@ -1247,10 +1246,9 @@ describe("OmpAdapter", () => {
         );
         yield* fake.offer(THREAD_ID, { type: "agent_end", messages: [], isTerminal: true });
         const events = yield* Fiber.join(eventsFiber);
-        const resolved = events.find(
-          (event) => event.type === "user-input.resolved" && event.requestId === "ask-select-2",
-        );
+        const resolved = events.find((event) => event.type === "user-input.resolved");
         NodeAssert.ok(resolved);
+        NodeAssert.equal(resolved.requestId, "ask-select-2");
         NodeAssert.deepEqual(resolved.payload.answers, {});
         NodeAssert.equal(
           events.some((event) => event.type === "turn.completed"),

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -180,13 +180,27 @@ function asSpawnedCommand(command: ChildProcess.Command): SpawnedCommand {
   };
 }
 
-function hasModeRpc(args: ReadonlyArray<string>): boolean {
+/** True only for the exact `--mode rpc-ui` pair; plain `rpc` and `=` forms fail. */
+function hasModeRpcUi(args: ReadonlyArray<string>): boolean {
   const modeIndex = args.indexOf("--mode");
-  return (modeIndex >= 0 && args[modeIndex + 1] === "rpc") || args.includes("--mode=rpc");
+  return (
+    modeIndex >= 0 &&
+    args[modeIndex + 1] === "rpc-ui" &&
+    !args.includes("--mode=rpc") &&
+    !args.includes("--mode=rpc-ui")
+  );
 }
 
-function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
+function makeFakeOmpSpawner(input: {
+  readonly sessionFile: string;
+  /** Plain-CLI `--help` output the capability probe reads. */
+  readonly helpText?: string;
+  /** Exit code the `--help` probe observes. */
+  readonly helpExitCode?: number;
+}) {
   const spawns: FakeOmpSpawn[] = [];
+  const helpText = input.helpText ?? "Usage: omp [options] --mode text|json|rpc|rpc-ui ...";
+  const helpExitCode = input.helpExitCode ?? 0;
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const spawner = ChildProcessSpawner.make((command) =>
@@ -194,13 +208,6 @@ function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
       const stdout = yield* Queue.unbounded<Uint8Array>();
       const offer = (frame: unknown) =>
         Queue.offer(stdout, encoder.encode(`${encodeUnknownJson(frame)}\n`));
-      yield* offer({
-        type: "ready",
-        protocolVersion: 1,
-        supportedProtocolVersions: [1, 2],
-        maxFrameBytes: MAX_RPC_FRAME_BYTES,
-        maxReassembledFrameBytes: MAX_RPC_REASSEMBLED_BYTES,
-      });
       const spawned = asSpawnedCommand(command);
       const spawn: FakeOmpSpawn = {
         ...spawned,
@@ -209,6 +216,37 @@ function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
         exit: yield* Deferred.make<ChildProcessSpawner.ExitCode, never>(),
       };
       spawns.push(spawn);
+
+      // `omp --help` capability probes are plain CLI, not RPC: write help text
+      // to stdout, end the stream, and resolve the exit code.
+      if (command.args.includes("--help")) {
+        yield* Queue.offer(stdout, encoder.encode(helpText));
+        yield* Queue.shutdown(stdout);
+        yield* Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(helpExitCode)).pipe(
+          Effect.asVoid,
+        );
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(spawns.length),
+          exitCode: Deferred.await(spawn.exit),
+          isRunning: Effect.sync(() => !spawn.killed),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.fromQueue(stdout),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        });
+      }
+
+      yield* offer({
+        type: "ready",
+        protocolVersion: 1,
+        supportedProtocolVersions: [1, 2],
+        maxFrameBytes: MAX_RPC_FRAME_BYTES,
+        maxReassembledFrameBytes: MAX_RPC_REASSEMBLED_BYTES,
+      });
       let sessionFile = input.sessionFile;
       let stdinBuf = "";
       return ChildProcessSpawner.makeHandle({
@@ -293,7 +331,7 @@ function makeFakeOmpSpawner(input: { readonly sessionFile: string }) {
 }
 
 describe("OmpRpcRuntime", () => {
-  it.effect("spawns the configured binary in rpc mode without disabling extensions", () =>
+  it.effect("spawns the configured binary in rpc-ui mode without disabling extensions", () =>
     Effect.gen(function* () {
       const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
       const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp", {
@@ -304,15 +342,147 @@ describe("OmpRpcRuntime", () => {
         cwd: "/proj",
         resumeCursor: null,
       });
-      NodeAssert.equal(fake.spawns.length, 1);
+      // Spawn order: capability probe first, then the session child.
+      NodeAssert.equal(fake.spawns.length, 2);
       NodeAssert.equal(fake.spawns[0]?.command, "/opt/omp");
-      NodeAssert.ok(hasModeRpc(fake.spawns[0]?.args ?? []));
-      NodeAssert.ok(!(fake.spawns[0]?.args ?? []).includes("--no-extensions"));
-      NodeAssert.equal(fake.spawns[0]?.options.cwd, "/proj");
-      NodeAssert.equal(fake.spawns[0]?.options.extendEnv, true);
-      NodeAssert.deepEqual(fake.spawns[0]?.options.stdin, { stream: "pipe", endOnDone: false });
-      const pathEnv = fake.spawns[0]?.options.env?.PATH ?? "";
+      NodeAssert.deepEqual(fake.spawns[0]?.args, ["--help"]);
+      NodeAssert.equal(fake.spawns[1]?.command, "/opt/omp");
+      NodeAssert.ok(hasModeRpcUi(fake.spawns[1]?.args ?? []));
+      NodeAssert.ok(!(fake.spawns[1]?.args ?? []).includes("--no-extensions"));
+      NodeAssert.equal(fake.spawns[1]?.options.cwd, "/proj");
+      NodeAssert.equal(fake.spawns[1]?.options.extendEnv, true);
+      NodeAssert.deepEqual(fake.spawns[1]?.options.stdin, { stream: "pipe", endOnDone: false });
+      const pathEnv = fake.spawns[1]?.options.env?.PATH ?? "";
       NodeAssert.ok(pathEnv.includes("/managed/rtk/current"));
+    }),
+  );
+
+  it.effect("fails closed when the omp binary does not advertise rpc-ui", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({
+        sessionFile: "/tmp/omp-session.jsonl",
+        helpText: "Usage: omp --mode text|json|rpc",
+      });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      const outcome = yield* Effect.exit(
+        runtime.ensureSession({
+          sessionKey: "thread-1",
+          cwd: "/proj",
+          resumeCursor: null,
+        }),
+      );
+      NodeAssert.equal(Exit.isFailure(outcome), true);
+      if (Exit.isFailure(outcome)) {
+        const error = Cause.squash(outcome.cause);
+        NodeAssert.ok(isOmpSpawnError(error));
+        NodeAssert.equal(error.operation, "capability");
+        NodeAssert.match(error.detail, /rpc-ui/);
+      }
+      // Only the --help probe ran: no session spawn and no --mode args at all
+      // (pins the no-silent-rpc-fallback contract).
+      NodeAssert.equal(fake.spawns.length, 1);
+      NodeAssert.ok(fake.spawns[0]?.args.includes("--help"));
+      NodeAssert.equal(
+        fake.spawns.some((spawn) => spawn.args.includes("--mode")),
+        false,
+      );
+    }),
+  );
+
+  it.effect("fails closed when the --help probe exits non-zero", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({
+        sessionFile: "/tmp/omp-session.jsonl",
+        helpExitCode: 2,
+      });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      const outcome = yield* Effect.exit(
+        runtime.ensureSession({
+          sessionKey: "thread-1",
+          cwd: "/proj",
+          resumeCursor: null,
+        }),
+      );
+      NodeAssert.equal(Exit.isFailure(outcome), true);
+      if (Exit.isFailure(outcome)) {
+        const error = Cause.squash(outcome.cause);
+        NodeAssert.ok(isOmpSpawnError(error));
+        NodeAssert.equal(error.operation, "capability");
+      }
+      NodeAssert.equal(fake.spawns.length, 1);
+      NodeAssert.equal(
+        fake.spawns.some((spawn) => spawn.args.includes("--mode")),
+        false,
+      );
+    }),
+  );
+
+  it.effect("probes rpc-ui support once and reuses the result across sessions", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      yield* runtime.ensureSession({
+        sessionKey: "thread-a",
+        cwd: "/proj-a",
+        resumeCursor: null,
+      });
+      yield* runtime.ensureSession({
+        sessionKey: "thread-b",
+        cwd: "/proj-b",
+        resumeCursor: null,
+      });
+      NodeAssert.equal(fake.spawns.length, 3);
+      NodeAssert.equal(fake.spawns.filter((spawn) => spawn.args.includes("--help")).length, 1);
+    }),
+  );
+
+  it.effect("probes rpc-ui support once under concurrent ensureSession calls", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      const results = yield* Effect.all(
+        [
+          runtime.ensureSession({
+            sessionKey: "thread-a",
+            cwd: "/proj",
+            resumeCursor: null,
+          }),
+          runtime.ensureSession({
+            sessionKey: "thread-b",
+            cwd: "/proj",
+            resumeCursor: null,
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+      NodeAssert.equal(results.length, 2);
+      NodeAssert.equal(fake.spawns.length, 3);
+      NodeAssert.equal(fake.spawns.filter((spawn) => spawn.args.includes("--help")).length, 1);
+    }),
+  );
+
+  it.effect("re-probes rpc-ui support after setBinaryPath", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+      yield* runtime.ensureSession({
+        sessionKey: "thread-1",
+        cwd: "/proj",
+        resumeCursor: null,
+      });
+      runtime.setBinaryPath("/new/omp");
+      yield* runtime.ensureSession({
+        sessionKey: "thread-2",
+        cwd: "/proj",
+        resumeCursor: null,
+      });
+      NodeAssert.equal(fake.spawns.length, 4);
+      NodeAssert.equal(fake.spawns[0]?.command, "/opt/omp");
+      NodeAssert.ok(fake.spawns[0]?.args.includes("--help"));
+      NodeAssert.equal(fake.spawns[1]?.command, "/opt/omp");
+      NodeAssert.equal(fake.spawns[2]?.command, "/new/omp");
+      NodeAssert.ok(fake.spawns[2]?.args.includes("--help"));
+      NodeAssert.equal(fake.spawns[3]?.command, "/new/omp");
     }),
   );
 
@@ -326,10 +496,10 @@ describe("OmpRpcRuntime", () => {
         resumeCursor: null,
       });
       NodeAssert.deepEqual(
-        fake.spawns[0]?.commands.map((command) => command.type),
+        fake.spawns[1]?.commands.map((command) => command.type),
         ["negotiate_protocol", "get_state"],
       );
-      NodeAssert.equal(fake.spawns[0]?.commands[0]?.protocolVersion, 2);
+      NodeAssert.equal(fake.spawns[1]?.commands[0]?.protocolVersion, 2);
       NodeAssert.equal(handle.sessionKey, "thread-1");
       NodeAssert.equal(handle.sessionFile, "/tmp/omp-session.jsonl");
     }),
@@ -345,10 +515,10 @@ describe("OmpRpcRuntime", () => {
         resumeCursor: "/tmp/existing.jsonl",
       });
       NodeAssert.deepEqual(
-        fake.spawns[0]?.commands.map((command) => command.type),
+        fake.spawns[1]?.commands.map((command) => command.type),
         ["negotiate_protocol", "switch_session", "get_state"],
       );
-      NodeAssert.equal(fake.spawns[0]?.commands[1]?.sessionPath, "/tmp/existing.jsonl");
+      NodeAssert.equal(fake.spawns[1]?.commands[1]?.sessionPath, "/tmp/existing.jsonl");
       NodeAssert.equal(handle.sessionFile, "/tmp/existing.jsonl");
     }),
   );
@@ -367,9 +537,9 @@ describe("OmpRpcRuntime", () => {
         cwd: "/proj-b",
         resumeCursor: null,
       });
-      NodeAssert.equal(fake.spawns.length, 2);
-      NodeAssert.equal(fake.spawns[0]?.options.cwd, "/proj-a");
-      NodeAssert.equal(fake.spawns[1]?.options.cwd, "/proj-b");
+      NodeAssert.equal(fake.spawns.length, 3);
+      NodeAssert.equal(fake.spawns[1]?.options.cwd, "/proj-a");
+      NodeAssert.equal(fake.spawns[2]?.options.cwd, "/proj-b");
     }),
   );
 
@@ -396,10 +566,10 @@ describe("OmpRpcRuntime", () => {
       let observed = false;
       for (let i = 0; i < 100 && !observed; i++) {
         yield* Effect.yieldNow;
-        observed = (fake.spawns[0]?.commands ?? []).length >= 1;
+        observed = (fake.spawns[1]?.commands ?? []).length >= 1;
       }
       NodeAssert.equal(observed, true);
-      yield* fake.exitSpawn(fake.spawns[0]!, 137);
+      yield* fake.exitSpawn(fake.spawns[1]!, 137);
       const sendOutcome = yield* Fiber.join(sendFiber).pipe(Effect.exit);
       NodeAssert.equal(Exit.isFailure(sendOutcome), true);
       if (Exit.isFailure(sendOutcome)) {
@@ -430,15 +600,15 @@ describe("OmpRpcRuntime", () => {
         cwd: "/proj",
         resumeCursor: null,
       });
-      NodeAssert.equal(fake.spawns.length, 1);
+      NodeAssert.equal(fake.spawns.length, 2);
       yield* runtime.dispose("thread-1");
-      NodeAssert.equal(fake.spawns[0]?.killed, true);
+      NodeAssert.equal(fake.spawns[1]?.killed, true);
       yield* runtime.ensureSession({
         sessionKey: "thread-1",
         cwd: "/proj",
         resumeCursor: null,
       });
-      NodeAssert.equal(fake.spawns.length, 2);
+      NodeAssert.equal(fake.spawns.length, 3);
     }),
   );
 
@@ -463,8 +633,8 @@ describe("OmpRpcRuntime", () => {
           response.success,
         true,
       );
-      NodeAssert.equal(fake.spawns[0]?.commands.at(-1)?.type, "prompt");
-      NodeAssert.equal(fake.spawns[0]?.commands.at(-1)?.message, "hi");
+      NodeAssert.equal(fake.spawns[1]?.commands.at(-1)?.type, "prompt");
+      NodeAssert.equal(fake.spawns[1]?.commands.at(-1)?.message, "hi");
       NodeAssert.equal(
         events[0] && typeof events[0] === "object" && "type" in events[0]
           ? events[0].type

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -220,7 +220,7 @@ function makeFakeOmpSpawner(input: {
       // `omp --help` capability probes are plain CLI, not RPC: emit the help
       // text as a finite stdout stream and resolve the exit code (mirrors the
       // plain-CLI `--version` branches in OmpDriver.test.ts).
-      if (command.args.includes("--help")) {
+      if (spawned.args.includes("--help")) {
         yield* Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(helpExitCode)).pipe(
           Effect.asVoid,
         );

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -217,11 +217,10 @@ function makeFakeOmpSpawner(input: {
       };
       spawns.push(spawn);
 
-      // `omp --help` capability probes are plain CLI, not RPC: write help text
-      // to stdout, end the stream, and resolve the exit code.
+      // `omp --help` capability probes are plain CLI, not RPC: emit the help
+      // text as a finite stdout stream and resolve the exit code (mirrors the
+      // plain-CLI `--version` branches in OmpDriver.test.ts).
       if (command.args.includes("--help")) {
-        yield* Queue.offer(stdout, encoder.encode(helpText));
-        yield* Queue.shutdown(stdout);
         yield* Deferred.succeed(spawn.exit, ChildProcessSpawner.ExitCode(helpExitCode)).pipe(
           Effect.asVoid,
         );
@@ -232,7 +231,7 @@ function makeFakeOmpSpawner(input: {
           kill: () => Effect.void,
           unref: Effect.succeed(Effect.void),
           stdin: Sink.drain,
-          stdout: Stream.fromQueue(stdout),
+          stdout: Stream.make(encoder.encode(helpText)),
           stderr: Stream.empty,
           all: Stream.empty,
           getInputFd: () => Sink.drain,

--- a/apps/server/src/provider/omp/OmpRpcRuntime.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.ts
@@ -1,9 +1,12 @@
 /**
- * OmpRpcRuntime — process owner for `omp --mode rpc` over stdio NDJSON.
+ * OmpRpcRuntime — process owner for `omp --mode rpc-ui` over stdio NDJSON.
  *
  * Owns spawn/kill, protocol v2 negotiate, strict rpc_chunk reassembly,
  * request correlation, and resume via switch_session. Adapter code maps
  * logical frames; this module never invents ProviderRuntimeEvent values.
+ * Every session spawn is gated on a lazy `--help` capability probe so an
+ * omp binary too old for `rpc-ui` (and its UI-gated `ask` tool) fails fast
+ * instead of silently losing the capability.
  *
  * @module provider/omp/OmpRpcRuntime
  */
@@ -196,7 +199,7 @@ export interface OmpRpcRuntimeOptions {
 }
 
 /**
- * Spawns and owns one `omp --mode rpc` child per T3 thread session.
+ * Spawns and owns one `omp --mode rpc-ui` child per T3 thread session.
  */
 export class OmpRpcRuntime {
   readonly #sessions = new Map<string, LiveOmpSession>();
@@ -204,6 +207,8 @@ export class OmpRpcRuntime {
   readonly #processSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   #binaryPath: string;
   readonly #pathPrefixDirs: ReadonlyArray<string>;
+  /** Single-flight capability memo: one `--help` probe per binary path. */
+  #rpcUiSupport: Deferred.Deferred<boolean, OmpSpawnError> | null = null;
 
   public constructor(
     processSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"],
@@ -218,6 +223,8 @@ export class OmpRpcRuntime {
   /** Update the spawn binary after a managed install/refresh. */
   public setBinaryPath(binaryPath: string): void {
     this.#binaryPath = binaryPath;
+    // A refreshed binary may have gained rpc-ui support — re-probe on next session.
+    this.#rpcUiSupport = null;
   }
 
   public ensureSession(
@@ -229,6 +236,18 @@ export class OmpRpcRuntime {
         return existing.handle;
       }
 
+      // Capability gate (new sessions only): fail fast before spawning when the
+      // binary is too old for `--mode rpc-ui` (and its UI-gated `ask` tool).
+      // Never falls back to plain `--mode rpc` — that would silently lose the
+      // ask capability. Probe failure also fails closed.
+      const supported = yield* this.probeRpcUiSupport(input.cwd);
+      if (!supported) {
+        return yield* new OmpSpawnError({
+          operation: "capability",
+          detail: `Configured omp binary (${this.#binaryPath}) is too old to support --mode rpc-ui, which the ask tool requires. Update omp (Settings → omp → Update) or set Binary path to a newer omp.`,
+        });
+      }
+
       const platform = yield* HostProcessPlatform;
       const preferredPath =
         this.#pathPrefixDirs.length > 0
@@ -238,7 +257,7 @@ export class OmpRpcRuntime {
       const scope = yield* Scope.make();
       const child = yield* this.#processSpawner
         .spawn(
-          ChildProcess.make(this.#binaryPath, ["--mode", "rpc"], {
+          ChildProcess.make(this.#binaryPath, ["--mode", "rpc-ui"], {
             cwd: input.cwd,
             extendEnv: true,
             ...(mergedPath !== undefined ? { env: { PATH: mergedPath } } : {}),
@@ -253,7 +272,7 @@ export class OmpRpcRuntime {
             (cause) =>
               new OmpSpawnError({
                 operation: "spawn",
-                detail: "failed to spawn omp --mode rpc",
+                detail: "failed to spawn omp --mode rpc-ui",
                 cause,
               }),
           ),
@@ -265,7 +284,7 @@ export class OmpRpcRuntime {
 
       // Watch for child death (crash, host restart, kill from outside) and
       // surface it to every in-flight request and to the frame stream. Without
-      // this a dead `omp --mode rpc` leaves awaiting Deferreds hanging and
+      // this a dead `omp --mode rpc-ui` leaves awaiting Deferreds hanging and
       // `streamFrames` idle forever: the adapter never settles the turn and the
       // thread stays "running" in the UI with a stop button that does nothing.
       yield* child.exitCode.pipe(
@@ -432,6 +451,81 @@ export class OmpRpcRuntime {
       yield* live.child.kill().pipe(Effect.ignore);
       yield* Scope.close(live.scope, Exit.void).pipe(Effect.ignore);
     });
+  }
+
+  /**
+   * Single-flight `--help` capability probe: `supported = exit 0 && help
+   * lists rpc-ui`. Memoized per binary path; `setBinaryPath` clears the memo.
+   * Probe failure fails closed — never assume rpc-ui support.
+   */
+  private probeRpcUiSupport(cwd: string): Effect.Effect<boolean, OmpSpawnError> {
+    return Effect.gen({ self: this }, function* () {
+      const existing = this.#rpcUiSupport;
+      if (existing) {
+        return yield* Deferred.await(existing);
+      }
+      const deferred = yield* Deferred.make<boolean, OmpSpawnError>();
+      this.#rpcUiSupport = deferred;
+      const outcome = yield* this.#runCapabilityProbe(cwd).pipe(Effect.exit);
+      yield* Deferred.done(deferred, outcome).pipe(Effect.ignore);
+      return yield* Deferred.await(deferred);
+    });
+  }
+
+  #runCapabilityProbe(cwd: string): Effect.Effect<boolean, OmpSpawnError> {
+    return Effect.gen({ self: this }, function* () {
+      const platform = yield* HostProcessPlatform;
+      const preferredPath =
+        this.#pathPrefixDirs.length > 0
+          ? this.#pathPrefixDirs.join(platform === "win32" ? ";" : ":")
+          : undefined;
+      const mergedPath = mergePathValues(preferredPath, process.env.PATH, platform);
+      const child = yield* this.#processSpawner
+        .spawn(
+          ChildProcess.make(this.#binaryPath, ["--help"], {
+            cwd,
+            extendEnv: true,
+            ...(mergedPath !== undefined ? { env: { PATH: mergedPath } } : {}),
+          }),
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new OmpSpawnError({
+                operation: "capability",
+                detail: `could not verify rpc-ui support for ${this.#binaryPath}: failed to spawn --help`,
+                cause,
+              }),
+          ),
+        );
+      const [output, exitCode] = yield* Effect.all(
+        [
+          child.stdout.pipe(
+            Stream.decodeText(),
+            Stream.runFold(
+              () => "",
+              (acc, chunk) => acc + chunk,
+            ),
+            Effect.orElseSucceed(() => ""),
+          ),
+          child.exitCode.pipe(
+            Effect.map(Number),
+            Effect.orElseSucceed(() => 1),
+          ),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            new OmpSpawnError({
+              operation: "capability",
+              detail: `could not verify rpc-ui support for ${this.#binaryPath}`,
+              cause,
+            }),
+        ),
+      );
+      return exitCode === 0 && output.includes("rpc-ui");
+    }).pipe(Effect.scoped);
   }
 
   #request(

--- a/apps/server/src/textGeneration/OmpTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OmpTextGeneration.test.ts
@@ -47,6 +47,22 @@ function makeFakeOmpSpawner(sessionFile: string) {
         supportedProtocolVersions: [1, 2],
       });
       asSpawnedCommand(command);
+      // `omp --help` capability probes are plain CLI, not RPC.
+      if (command.args.includes("--help")) {
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.make(encoder.encode("Usage: omp [options] --mode text|json|rpc|rpc-ui\n")),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        });
+      }
       const exit = yield* Deferred.make<ChildProcessSpawner.ExitCode, never>();
       let stdinBuf = "";
       return ChildProcessSpawner.makeHandle({

--- a/apps/server/src/textGeneration/OmpTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OmpTextGeneration.test.ts
@@ -46,9 +46,9 @@ function makeFakeOmpSpawner(sessionFile: string) {
         protocolVersion: 1,
         supportedProtocolVersions: [1, 2],
       });
-      asSpawnedCommand(command);
+      const spawned = asSpawnedCommand(command);
       // `omp --help` capability probes are plain CLI, not RPC.
-      if (command.args.includes("--help")) {
+      if (spawned.args.includes("--help")) {
         return ChildProcessSpawner.makeHandle({
           pid: ChildProcessSpawner.ProcessId(1),
           exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),

--- a/docs/user/providers-omp.md
+++ b/docs/user/providers-omp.md
@@ -1,6 +1,6 @@
 # omp
 
-Pivot drives [omp](https://omp.sh) over `omp --mode rpc`. omp is the only built-in agent backend.
+Pivot drives [omp](https://omp.sh) over `omp --mode rpc-ui`. omp is the only built-in agent backend.
 
 ## Install
 
@@ -28,6 +28,8 @@ Model lists come from omp (`get_available_models`), not from a hardcoded catalog
 Login runs on the machine hosting the Pivot server (browser opens there; OAuth callbacks stay there). You can also sign in from a terminal on that host with `omp login`.
 
 When omp asks for a confirmation, a paste code, a proposed host-URI edit, or a choice (including login paste prompts), Pivot shows the existing approval / user-input panels in the composer. Your answer is sent back to omp over RPC (`extension_ui_response` or `host_uri_result`).
+
+omp's built-in `ask` tool renders its questions in those same user-input panels (selects and inputs); your answer returns over `extension_ui_response` and the turn continues. Cancelling the question (or stopping the turn) settles it cleanly — omp resolves the ask and the turn is not left hanging. Pivot spawns omp in `rpc-ui` mode so the `ask` tool is available; a user-supplied omp binary too old for `rpc-ui` fails thread startup with an upgrade error instead of silently losing the capability.
 
 Type `/` in the composer to see omp slash commands (from `get_available_commands`), such as `/model`, `/review`, or `/jobs`. Choosing one inserts the command into the prompt. Local commands that omp handles without starting an agent turn (for example `/jobs`) show their result in the chat.
 


### PR DESCRIPTION
## What Changed

Every OMP child Pivot spawns now runs `--mode rpc-ui` instead of `--mode rpc`, so sessions carry `hasUI` and the built-in `ask` tool is available. New-session spawns are gated on a lazy `--help` capability probe: a user-supplied omp binary too old for `rpc-ui` fails fast with an actionable upgrade error instead of silently falling back to plain `rpc`. The ask flow (select → user-input panel → answer → `extension_ui_response` → turn continues) is pinned end-to-end at the adapter level, including cancel and interrupt variants.

## Why

`--mode rpc` never installs the tool-UI context, so Pivot-hosted agents can't ask the user a structured mid-turn question. `rpc-ui` is the same RPC transport but enables `ask`, and Pivot's adapter already bridges the `extension_ui_request` frames to the existing user-input panels.

## UI Changes

No visual change — makes the existing user-input panels reachable. User doc updated (`docs/user/providers-omp.md`).

Closes #40
