### PR TITLE
fix(web): Other option focuses composer for a custom answer

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1867,6 +1867,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     });
   }, []);
 
+  /** "Other (type your own)" option clicked: let the user type an answer. */
+  const requestPendingUserInputCustomAnswer = useCallback(() => {
+    if (isComposerCollapsedMobile) {
+      expandMobileComposer();
+      return;
+    }
+    focusComposer();
+  }, [isComposerCollapsedMobile, expandMobileComposer, focusComposer]);
+
   // ------------------------------------------------------------------
   // Callbacks: command key
   // ------------------------------------------------------------------
@@ -2720,6 +2729,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   questionIndex={activePendingQuestionIndex}
                   onToggleOption={onSelectActivePendingUserInputOption}
                   onAdvance={onAdvanceActivePendingUserInput}
+                  onRequestCustomAnswer={requestPendingUserInputCustomAnswer}
                 />
               </div>
             ) : showPlanFollowUpPrompt && activeProposedPlan ? (
@@ -2760,6 +2770,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 questionIndex={activePendingQuestionIndex}
                 onToggleOption={onSelectActivePendingUserInputOption}
                 onAdvance={onAdvanceActivePendingUserInput}
+                onRequestCustomAnswer={requestPendingUserInputCustomAnswer}
               />
               <div className="px-3 pb-3 sm:px-4">
                 <div

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -3,6 +3,8 @@ import { memo, useEffect, useEffectEvent, useRef, useState } from "react";
 import { type PendingUserInput } from "../../session-logic";
 import {
   derivePendingUserInputProgress,
+  shouldAutoAdvancePendingUserInputSelection,
+  shouldRequestCustomAnswerForPendingUserInput,
   type PendingUserInputDraftAnswer,
 } from "../../pendingUserInput";
 import { CheckIcon } from "lucide-react";
@@ -15,6 +17,8 @@ interface PendingUserInputPanelProps {
   questionIndex: number;
   onToggleOption: (questionId: string, optionLabel: string) => void;
   onAdvance: () => void;
+  /** Focus the composer so the user can type a free-text answer. */
+  onRequestCustomAnswer: () => void;
 }
 
 export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserInputPanel({
@@ -24,6 +28,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
   questionIndex,
   onToggleOption,
   onAdvance,
+  onRequestCustomAnswer,
 }: PendingUserInputPanelProps) {
   if (pendingUserInputs.length === 0) return null;
   const activePrompt = pendingUserInputs[0];
@@ -38,6 +43,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
       questionIndex={questionIndex}
       onToggleOption={onToggleOption}
       onAdvance={onAdvance}
+      onRequestCustomAnswer={onRequestCustomAnswer}
     />
   );
 });
@@ -49,6 +55,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   questionIndex,
   onToggleOption,
   onAdvance,
+  onRequestCustomAnswer,
 }: {
   prompt: PendingUserInput;
   isResponding: boolean;
@@ -56,6 +63,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   questionIndex: number;
   onToggleOption: (questionId: string, optionLabel: string) => void;
   onAdvance: () => void;
+  onRequestCustomAnswer: () => void;
 }) {
   const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
   const activeQuestion = progress.activeQuestion;
@@ -101,12 +109,34 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   }, []);
 
   const handleOptionSelection = useEffectEvent((questionId: string, optionLabel: string) => {
-    if (activeQuestion?.multiSelect) {
+    if (!activeQuestion) {
+      return;
+    }
+    const requestCustomAnswer = shouldRequestCustomAnswerForPendingUserInput(
+      activeQuestion,
+      optionLabel,
+      progress.selectedOptionLabels,
+    );
+    if (activeQuestion.multiSelect) {
       onToggleOption(questionId, optionLabel);
+      if (requestCustomAnswer) {
+        onRequestCustomAnswer();
+      }
       return;
     }
     setOptimisticSingleSelect({ questionId, optionLabel });
     onToggleOption(questionId, optionLabel);
+    if (requestCustomAnswer) {
+      // "Other (type your own)": hand off to the composer instead of
+      // auto-submitting the literal label after the delay.
+      onRequestCustomAnswer();
+      return;
+    }
+    // Only ordinary single-select options auto-advance; the free-text and
+    // multi-select paths already returned above.
+    if (!shouldAutoAdvancePendingUserInputSelection(activeQuestion, optionLabel)) {
+      return;
+    }
     if (autoAdvanceTimerRef.current !== null) {
       window.clearTimeout(autoAdvanceTimerRef.current);
     }

--- a/apps/web/src/pendingUserInput.test.ts
+++ b/apps/web/src/pendingUserInput.test.ts
@@ -5,8 +5,11 @@ import {
   countAnsweredPendingUserInputQuestions,
   derivePendingUserInputProgress,
   findFirstUnansweredPendingUserInputQuestionIndex,
+  isFreeTextOptionLabel,
   resolvePendingUserInputAnswer,
   setPendingUserInputCustomAnswer,
+  shouldAutoAdvancePendingUserInputSelection,
+  shouldRequestCustomAnswerForPendingUserInput,
   togglePendingUserInputOptionSelection,
 } from "./pendingUserInput";
 
@@ -246,5 +249,84 @@ describe("pending user input question progress", () => {
       canAdvance: true,
       isComplete: true,
     });
+  });
+});
+
+const singleSelectWithOther = {
+  id: "storage",
+  header: "Storage",
+  question: "Which storage backend?",
+  options: [
+    { label: "local", description: "local" },
+    { label: "s3", description: "s3" },
+    { label: "Other", description: "Other" },
+  ],
+  multiSelect: false,
+} as const;
+
+describe("isFreeTextOptionLabel", () => {
+  it("matches the exact label Other", () => {
+    expect(isFreeTextOptionLabel("Other")).toBe(true);
+  });
+
+  it("matches omp's TUI 'Other (type your own)' form, case-insensitively", () => {
+    expect(isFreeTextOptionLabel("Other (type your own)")).toBe(true);
+    expect(isFreeTextOptionLabel("other (type your own)")).toBe(true);
+  });
+
+  it("does not match ordinary option labels", () => {
+    expect(isFreeTextOptionLabel("local")).toBe(false);
+    expect(isFreeTextOptionLabel("s3")).toBe(false);
+    expect(isFreeTextOptionLabel("Others")).toBe(false);
+    expect(isFreeTextOptionLabel("")).toBe(false);
+  });
+});
+
+describe("shouldAutoAdvancePendingUserInputSelection", () => {
+  it("auto-advances single-select ordinary options", () => {
+    expect(shouldAutoAdvancePendingUserInputSelection(singleSelectWithOther, "s3")).toBe(true);
+  });
+
+  it("never auto-advances a free-text option (clicking Other must not submit the literal label)", () => {
+    expect(shouldAutoAdvancePendingUserInputSelection(singleSelectWithOther, "Other")).toBe(false);
+    expect(
+      shouldAutoAdvancePendingUserInputSelection(singleSelectWithOther, "Other (type your own)"),
+    ).toBe(false);
+  });
+
+  it("never auto-advances multi-select questions", () => {
+    expect(shouldAutoAdvancePendingUserInputSelection(multiSelectQuestion, "Server")).toBe(false);
+  });
+});
+
+describe("shouldRequestCustomAnswerForPendingUserInput", () => {
+  it("requests a custom answer for a single-select free-text option", () => {
+    expect(shouldRequestCustomAnswerForPendingUserInput(singleSelectWithOther, "Other", [])).toBe(
+      true,
+    );
+  });
+
+  it("requests a custom answer when adding a free-text option to a multi-select question", () => {
+    expect(
+      shouldRequestCustomAnswerForPendingUserInput(multiSelectQuestion, "Other", ["Server"]),
+    ).toBe(true);
+  });
+
+  it("does not request a custom answer when removing a free-text option from a multi-select question", () => {
+    expect(
+      shouldRequestCustomAnswerForPendingUserInput(multiSelectQuestion, "Other", [
+        "Server",
+        "Other",
+      ]),
+    ).toBe(false);
+  });
+
+  it("does not request a custom answer for ordinary options", () => {
+    expect(shouldRequestCustomAnswerForPendingUserInput(singleSelectWithOther, "s3", [])).toBe(
+      false,
+    );
+    expect(shouldRequestCustomAnswerForPendingUserInput(multiSelectQuestion, "Server", [])).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/pendingUserInput.ts
+++ b/apps/web/src/pendingUserInput.ts
@@ -77,6 +77,40 @@ export function setPendingUserInputCustomAnswer(
   };
 }
 
+/**
+ * Option labels that mean "type your own answer" rather than a literal value.
+ * Mirrors omp's TUI `Other (type your own)` entry, which agents echo when they
+ * offer a fallback option.
+ */
+export function isFreeTextOptionLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase();
+  return normalized === "other" || normalized.startsWith("other (");
+}
+
+/** Single-select ordinary options auto-advance; free-text options never do. */
+export function shouldAutoAdvancePendingUserInputSelection(
+  question: UserInputQuestion,
+  optionLabel: string,
+): boolean {
+  return !question.multiSelect && !isFreeTextOptionLabel(optionLabel);
+}
+
+/**
+ * A free-text option click should focus the composer for a typed answer:
+ * always for single-select, and for multi-select only while the option is
+ * being added (removing it must not steal focus).
+ */
+export function shouldRequestCustomAnswerForPendingUserInput(
+  question: UserInputQuestion,
+  optionLabel: string,
+  currentlySelectedOptionLabels: ReadonlyArray<string>,
+): boolean {
+  if (!isFreeTextOptionLabel(optionLabel)) {
+    return false;
+  }
+  return question.multiSelect ? !currentlySelectedOptionLabels.includes(optionLabel) : true;
+}
+
 export function togglePendingUserInputOptionSelection(
   question: UserInputQuestion,
   draft: PendingUserInputDraftAnswer | undefined,


### PR DESCRIPTION
## What Changed

Clicking a free-text "Other" option in the pending user-input panel now focuses the composer so you can type a custom answer, instead of auto-submitting the literal "Other" label after 200ms. The typed text is what gets submitted; leaving it blank falls back to the selected option.

## Why

omp's TUI appends "Other (type your own)" and opens an input; Pivot's panel auto-advanced on any single-select click, so clicking "Other" submitted the literal string with no chance to type.

## UI Changes

Interaction change: clicking "Other" now focuses the composer (before: instant submit).
