### PR TITLE
fix(server): pass provider settings env into omp child processes

### DIFF
--- a/apps/server/src/provider/Drivers/OmpDriver.ts
+++ b/apps/server/src/provider/Drivers/OmpDriver.ts
@@ -330,7 +330,7 @@ export const OmpDriver: ProviderDriver<OmpSettings, OmpDriverEnv> = {
   },
   configSchema: OmpSettings,
   defaultConfig: (): OmpSettings => decodeOmpSettings({}),
-  create: ({ instanceId, displayName, accentColor, enabled, config }) =>
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const serverConfig = yield* ServerConfig.ServerConfig;
@@ -391,6 +391,7 @@ export const OmpDriver: ProviderDriver<OmpSettings, OmpDriverEnv> = {
 
       const runtime = new OmpRpcRuntime(spawner, launchBinary, {
         pathPrefixDirs: [rtkCurrentDir],
+        environment,
       });
       const fs = yield* FileSystem.FileSystem;
       const ompHomeEnv = process.env.OMP_HOME?.trim();
@@ -508,6 +509,7 @@ export const OmpDriver: ProviderDriver<OmpSettings, OmpDriverEnv> = {
         resolveBinaryPath: resolveBinary.pipe(
           Effect.map((resolved) => resolved.binaryPath ?? launchBinary),
         ),
+        environment,
       });
 
       return {

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -356,6 +356,28 @@ describe("OmpRpcRuntime", () => {
     }),
   );
 
+  it.effect("merges provider-instance environment into omp child spawns", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+      const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp", {
+        environment: [
+          { name: "DEEPINFRA_TOKEN", value: "di-test-token", sensitive: true },
+          { name: "OPENROUTER_API_KEY", value: "or-test", sensitive: true },
+        ],
+      });
+      yield* runtime.ensureSession({
+        sessionKey: "thread-1",
+        cwd: "/proj",
+        resumeCursor: null,
+      });
+      NodeAssert.equal(fake.spawns.length, 2);
+      for (const spawn of fake.spawns) {
+        NodeAssert.equal(spawn.options.env?.DEEPINFRA_TOKEN, "di-test-token");
+        NodeAssert.equal(spawn.options.env?.OPENROUTER_API_KEY, "or-test");
+      }
+    }),
+  );
+
   it.effect("fails closed when the omp binary does not advertise rpc-ui", () =>
     Effect.gen(function* () {
       const fake = makeFakeOmpSpawner({

--- a/apps/server/src/provider/omp/OmpRpcRuntime.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.ts
@@ -10,6 +10,7 @@
  *
  * @module provider/omp/OmpRpcRuntime
  */
+import type { ProviderInstanceEnvironment } from "@t3tools/contracts";
 import { mergePathValues } from "@t3tools/shared/shell";
 import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
@@ -21,6 +22,8 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 
 /** Maximum UTF-8 size of one newline-delimited RPC frame, including the newline. */
 export const MAX_RPC_FRAME_BYTES = 1024 * 1024;
@@ -196,6 +199,12 @@ interface LiveOmpSession {
 export interface OmpRpcRuntimeOptions {
   /** Directories prepended to PATH for the omp child (e.g. managed rtk). */
   readonly pathPrefixDirs?: ReadonlyArray<string>;
+  /**
+   * Provider-instance env from Pivot Settings. Merged into every omp child
+   * spawn (`extendEnv`) so custom `models.yml` providers can resolve keys like
+   * `DEEPINFRA_TOKEN` without exporting them in the server process.
+   */
+  readonly environment?: ProviderInstanceEnvironment;
 }
 
 /**
@@ -207,6 +216,7 @@ export class OmpRpcRuntime {
   readonly #processSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   #binaryPath: string;
   readonly #pathPrefixDirs: ReadonlyArray<string>;
+  readonly #environment: ProviderInstanceEnvironment;
   /** Single-flight capability memo: one `--help` probe per binary path. */
   #rpcUiSupport: Deferred.Deferred<boolean, OmpSpawnError> | null = null;
 
@@ -218,6 +228,30 @@ export class OmpRpcRuntime {
     this.#processSpawner = processSpawner;
     this.#binaryPath = binaryPath;
     this.#pathPrefixDirs = options?.pathPrefixDirs ?? [];
+    this.#environment = options?.environment ?? [];
+  }
+
+  /**
+   * Env overrides for `ChildProcess.make` with `extendEnv: true`: settings
+   * vars first, then PATH when path-prefix dirs are configured (PATH wins).
+   */
+  #childEnvOverrides(platform: NodeJS.Platform): Record<string, string> | undefined {
+    const preferredPath =
+      this.#pathPrefixDirs.length > 0
+        ? this.#pathPrefixDirs.join(platform === "win32" ? ";" : ":")
+        : undefined;
+    const mergedPath = mergePathValues(preferredPath, process.env.PATH, platform);
+    const fromSettings = mergeProviderInstanceEnvironment(this.#environment, {});
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(fromSettings)) {
+      if (value !== undefined) {
+        env[key] = value;
+      }
+    }
+    if (mergedPath !== undefined) {
+      env.PATH = mergedPath;
+    }
+    return Object.keys(env).length > 0 ? env : undefined;
   }
 
   /** Update the spawn binary after a managed install/refresh. */
@@ -249,18 +283,14 @@ export class OmpRpcRuntime {
       }
 
       const platform = yield* HostProcessPlatform;
-      const preferredPath =
-        this.#pathPrefixDirs.length > 0
-          ? this.#pathPrefixDirs.join(platform === "win32" ? ";" : ":")
-          : undefined;
-      const mergedPath = mergePathValues(preferredPath, process.env.PATH, platform);
+      const env = this.#childEnvOverrides(platform);
       const scope = yield* Scope.make();
       const child = yield* this.#processSpawner
         .spawn(
           ChildProcess.make(this.#binaryPath, ["--mode", "rpc-ui"], {
             cwd: input.cwd,
             extendEnv: true,
-            ...(mergedPath !== undefined ? { env: { PATH: mergedPath } } : {}),
+            ...(env !== undefined ? { env } : {}),
             // Keep stdin open across many RPC writes. Default endOnDone ends the
             // pipe after the first Stream.run, which hangs the next command.
             stdin: { stream: "pipe", endOnDone: false },
@@ -475,17 +505,13 @@ export class OmpRpcRuntime {
   #runCapabilityProbe(cwd: string): Effect.Effect<boolean, OmpSpawnError> {
     return Effect.gen({ self: this }, function* () {
       const platform = yield* HostProcessPlatform;
-      const preferredPath =
-        this.#pathPrefixDirs.length > 0
-          ? this.#pathPrefixDirs.join(platform === "win32" ? ";" : ":")
-          : undefined;
-      const mergedPath = mergePathValues(preferredPath, process.env.PATH, platform);
+      const env = this.#childEnvOverrides(platform);
       const child = yield* this.#processSpawner
         .spawn(
           ChildProcess.make(this.#binaryPath, ["--help"], {
             cwd,
             extendEnv: true,
-            ...(mergedPath !== undefined ? { env: { PATH: mergedPath } } : {}),
+            ...(env !== undefined ? { env } : {}),
           }),
         )
         .pipe(

--- a/apps/server/src/textGeneration/OmpTextGeneration.ts
+++ b/apps/server/src/textGeneration/OmpTextGeneration.ts
@@ -17,7 +17,12 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { type ModelSelection, type OmpSettings, TextGenerationError } from "@t3tools/contracts";
+import {
+  type ModelSelection,
+  type OmpSettings,
+  type ProviderInstanceEnvironment,
+  TextGenerationError,
+} from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { extractJsonObject } from "@t3tools/shared/schemaJson";
 
@@ -76,6 +81,7 @@ function mapOmpError(operation: string, cause: unknown, detail: string): TextGen
 export const makeOmpTextGeneration = Effect.fn("makeOmpTextGeneration")(function* (
   ompSettings: OmpSettings & {
     readonly resolveBinaryPath?: Effect.Effect<string>;
+    readonly environment?: ProviderInstanceEnvironment;
   },
 ) {
   const crypto = yield* Crypto.Crypto;
@@ -85,6 +91,7 @@ export const makeOmpTextGeneration = Effect.fn("makeOmpTextGeneration")(function
       ? ompSettings.binaryPath
       : "omp";
   const resolveBinaryPath = ompSettings.resolveBinaryPath ?? Effect.succeed(fallbackBinaryPath);
+  const environment = ompSettings.environment ?? [];
 
   const runOmpJson = <S extends Schema.Top>({
     operation,
@@ -105,7 +112,7 @@ export const makeOmpTextGeneration = Effect.fn("makeOmpTextGeneration")(function
   }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
     Effect.gen(function* () {
       const binaryPath = yield* resolveBinaryPath;
-      const runtime = new OmpRpcRuntime(commandSpawner, binaryPath);
+      const runtime = new OmpRpcRuntime(commandSpawner, binaryPath, { environment });
       const sessionKey = yield* crypto.randomUUIDv4.pipe(Effect.orDie);
       yield* Effect.addFinalizer(() => runtime.dispose(sessionKey));
 


### PR DESCRIPTION
## What Changed

- `OmpDriver` now forwards the provider-instance `environment` from Settings into `OmpRpcRuntime` and omp text-generation spawns.
- `OmpRpcRuntime` merges those vars into every omp child (`extendEnv`), alongside the existing PATH prefix for managed rtk.
- Added a unit test that asserts Settings env keys land on both the capability probe and rpc-ui spawn.

## Why

Settings → omp → Environment already stored keys but omp children only inherited the server process env. That made UI-configured keys invisible to omp, so custom providers never became available.

## UI Changes

N/A — existing Settings environment fields now take effect for omp.