### PR TITLE
feat(server): inject minted preview MCP into omp threads (#25)

### DIFF
--- a/apps/server/src/mcp/OmpPreviewMcpInjector.test.ts
+++ b/apps/server/src/mcp/OmpPreviewMcpInjector.test.ts
@@ -35,20 +35,26 @@ const sessionConfig: McpProviderSessionConfig = {
   authorizationHeader: "Bearer test-preview-token",
 };
 
+const makeOverlayFixture = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
+  const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+  const overlayHome = path.join(overlayRoot, THREAD_ID);
+  const overlayMcpJsonPath = path.join(overlayHome, ".cursor", "mcp.json");
+  return { fs, path, overlayRoot, overlayHome, overlayMcpJsonPath, injector };
+});
+
 it.layer(NodeServices.layer)("OmpPreviewMcpInjector", (it) => {
   it.effect(
     "Given a minted MCP session, When install runs, Then overlay mcp.json is pivot-preview HTTP with Authorization",
     () =>
       Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
-        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+        const { fs, overlayMcpJsonPath, injector } = yield* makeOverlayFixture;
 
         yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
 
-        const overlayPath = path.join(overlayRoot, THREAD_ID, ".cursor", "mcp.json");
-        const raw = yield* fs.readFileString(overlayPath);
+        const raw = yield* fs.readFileString(overlayMcpJsonPath);
         expect(decodeOverlayMcpJson(raw)).toEqual({
           mcpServers: {
             "pivot-preview": {
@@ -65,17 +71,27 @@ it.layer(NodeServices.layer)("OmpPreviewMcpInjector", (it) => {
     "Given a minted MCP session, When install runs, Then extraEnv sets HOME to the overlay and PI_CODING_AGENT_DIR to the agent dir",
     () =>
       Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
-        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+        const { overlayHome, injector } = yield* makeOverlayFixture;
 
         const installed = yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
 
         expect(installed.extraEnv).toEqual({
-          HOME: path.join(overlayRoot, THREAD_ID),
+          HOME: overlayHome,
           PI_CODING_AGENT_DIR: AGENT_DIR,
         });
+      }),
+  );
+
+  it.effect(
+    "Given a minted MCP session, When install runs, Then overlay mcp.json is mode 0o600",
+    () =>
+      Effect.gen(function* () {
+        const { fs, overlayMcpJsonPath, injector } = yield* makeOverlayFixture;
+
+        yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
+
+        const info = yield* fs.stat(overlayMcpJsonPath);
+        expect(info.mode & 0o777).toBe(0o600);
       }),
   );
 
@@ -83,12 +99,8 @@ it.layer(NodeServices.layer)("OmpPreviewMcpInjector", (it) => {
     "Given an installed overlay, When uninstall runs, Then the overlay directory is gone",
     () =>
       Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
-        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+        const { fs, overlayHome, injector } = yield* makeOverlayFixture;
         yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
-        const overlayHome = path.join(overlayRoot, THREAD_ID);
 
         yield* injector.uninstall(THREAD_ID);
 

--- a/apps/server/src/mcp/OmpPreviewMcpInjector.test.ts
+++ b/apps/server/src/mcp/OmpPreviewMcpInjector.test.ts
@@ -1,0 +1,98 @@
+import { expect, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { EnvironmentId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import type { McpProviderSessionConfig } from "./McpProviderSession.ts";
+import { OmpPreviewMcpInjector } from "./OmpPreviewMcpInjector.ts";
+
+const THREAD_ID = ThreadId.make("thread-preview-1");
+const AGENT_DIR = "/tmp/pivot-agent-dir";
+
+const OverlayMcpJson = Schema.Struct({
+  mcpServers: Schema.Struct({
+    "pivot-preview": Schema.Struct({
+      type: Schema.Literal("http"),
+      url: Schema.String,
+      headers: Schema.Struct({
+        Authorization: Schema.String,
+      }),
+    }),
+  }),
+});
+
+const decodeOverlayMcpJson = Schema.decodeSync(Schema.fromJsonString(OverlayMcpJson));
+
+const sessionConfig: McpProviderSessionConfig = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: THREAD_ID,
+  providerSessionId: "provider-session-1",
+  providerInstanceId: ProviderInstanceId.make("omp"),
+  endpoint: "http://127.0.0.1:43123/mcp",
+  authorizationHeader: "Bearer test-preview-token",
+};
+
+it.layer(NodeServices.layer)("OmpPreviewMcpInjector", (it) => {
+  it.effect(
+    "Given a minted MCP session, When install runs, Then overlay mcp.json is pivot-preview HTTP with Authorization",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
+        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+
+        yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
+
+        const overlayPath = path.join(overlayRoot, THREAD_ID, ".cursor", "mcp.json");
+        const raw = yield* fs.readFileString(overlayPath);
+        expect(decodeOverlayMcpJson(raw)).toEqual({
+          mcpServers: {
+            "pivot-preview": {
+              type: "http",
+              url: sessionConfig.endpoint,
+              headers: { Authorization: sessionConfig.authorizationHeader },
+            },
+          },
+        });
+      }),
+  );
+
+  it.effect(
+    "Given a minted MCP session, When install runs, Then extraEnv sets HOME to the overlay and PI_CODING_AGENT_DIR to the agent dir",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
+        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+
+        const installed = yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
+
+        expect(installed.extraEnv).toEqual({
+          HOME: path.join(overlayRoot, THREAD_ID),
+          PI_CODING_AGENT_DIR: AGENT_DIR,
+        });
+      }),
+  );
+
+  it.effect(
+    "Given an installed overlay, When uninstall runs, Then the overlay directory is gone",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
+        const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+        yield* injector.install(THREAD_ID, sessionConfig, AGENT_DIR);
+        const overlayHome = path.join(overlayRoot, THREAD_ID);
+
+        yield* injector.uninstall(THREAD_ID);
+
+        expect(yield* fs.exists(overlayHome)).toBe(false);
+      }),
+  );
+});

--- a/apps/server/src/mcp/OmpPreviewMcpInjector.ts
+++ b/apps/server/src/mcp/OmpPreviewMcpInjector.ts
@@ -19,11 +19,15 @@ const PREVIEW_MCP_SERVER_NAME = "pivot-preview";
 const OVERLAY_MCP_FILE_MODE = 0o600;
 
 export class OmpPreviewMcpInjector {
-  public constructor(
-    private readonly fileSystem: FileSystem.FileSystem,
-    private readonly path: Path.Path,
-    private readonly overlayRoot: string,
-  ) {}
+  readonly #fileSystem: FileSystem.FileSystem;
+  readonly #path: Path.Path;
+  readonly #overlayRoot: string;
+
+  public constructor(fileSystem: FileSystem.FileSystem, path: Path.Path, overlayRoot: string) {
+    this.#fileSystem = fileSystem;
+    this.#path = path;
+    this.#overlayRoot = overlayRoot;
+  }
 
   public install(
     threadId: ThreadId,
@@ -32,10 +36,10 @@ export class OmpPreviewMcpInjector {
   ): Effect.Effect<{ readonly extraEnv: Record<string, string> }> {
     return Effect.gen({ self: this }, function* () {
       const overlayHome = this.overlayHome(threadId);
-      const cursorDir = this.path.join(overlayHome, OVERLAY_CURSOR_DIR);
-      yield* this.fileSystem.makeDirectory(cursorDir, { recursive: true });
-      yield* this.fileSystem.writeFileString(
-        this.path.join(cursorDir, OVERLAY_MCP_FILENAME),
+      const cursorDir = this.#path.join(overlayHome, OVERLAY_CURSOR_DIR);
+      yield* this.#fileSystem.makeDirectory(cursorDir, { recursive: true });
+      yield* this.#fileSystem.writeFileString(
+        this.#path.join(cursorDir, OVERLAY_MCP_FILENAME),
         this.overlayDocument(config),
         { mode: OVERLAY_MCP_FILE_MODE },
       );
@@ -49,13 +53,13 @@ export class OmpPreviewMcpInjector {
   }
 
   public uninstall(threadId: ThreadId): Effect.Effect<void> {
-    return this.fileSystem
+    return this.#fileSystem
       .remove(this.overlayHome(threadId), { recursive: true, force: true })
       .pipe(Effect.orDie);
   }
 
   private overlayHome(threadId: ThreadId): string {
-    return this.path.join(this.overlayRoot, threadId);
+    return this.#path.join(this.#overlayRoot, threadId);
   }
 
   private overlayDocument(config: McpProviderSessionConfig): string {

--- a/apps/server/src/mcp/OmpPreviewMcpInjector.ts
+++ b/apps/server/src/mcp/OmpPreviewMcpInjector.ts
@@ -1,0 +1,72 @@
+/**
+ * Process-private Cursor MCP overlay so an omp child can reach Pivot `/mcp`.
+ *
+ * Writes `{overlayHome}/.cursor/mcp.json` and returns spawn env (`HOME` +
+ * `PI_CODING_AGENT_DIR`). Never writes user or project `mcp.json`.
+ *
+ * @module mcp/OmpPreviewMcpInjector
+ */
+import type { ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import type { McpProviderSessionConfig } from "./McpProviderSession.ts";
+
+const OVERLAY_CURSOR_DIR = ".cursor";
+const OVERLAY_MCP_FILENAME = "mcp.json";
+const PREVIEW_MCP_SERVER_NAME = "pivot-preview";
+const OVERLAY_MCP_FILE_MODE = 0o600;
+
+export class OmpPreviewMcpInjector {
+  public constructor(
+    private readonly fileSystem: FileSystem.FileSystem,
+    private readonly path: Path.Path,
+    private readonly overlayRoot: string,
+  ) {}
+
+  public install(
+    threadId: ThreadId,
+    config: McpProviderSessionConfig,
+    agentDir: string,
+  ): Effect.Effect<{ readonly extraEnv: Record<string, string> }> {
+    return Effect.gen({ self: this }, function* () {
+      const overlayHome = this.overlayHome(threadId);
+      const cursorDir = this.path.join(overlayHome, OVERLAY_CURSOR_DIR);
+      yield* this.fileSystem.makeDirectory(cursorDir, { recursive: true });
+      yield* this.fileSystem.writeFileString(
+        this.path.join(cursorDir, OVERLAY_MCP_FILENAME),
+        this.overlayDocument(config),
+        { mode: OVERLAY_MCP_FILE_MODE },
+      );
+      return {
+        extraEnv: {
+          HOME: overlayHome,
+          PI_CODING_AGENT_DIR: agentDir,
+        },
+      };
+    }).pipe(Effect.orDie);
+  }
+
+  public uninstall(threadId: ThreadId): Effect.Effect<void> {
+    return this.fileSystem
+      .remove(this.overlayHome(threadId), { recursive: true, force: true })
+      .pipe(Effect.orDie);
+  }
+
+  private overlayHome(threadId: ThreadId): string {
+    return this.path.join(this.overlayRoot, threadId);
+  }
+
+  private overlayDocument(config: McpProviderSessionConfig): string {
+    return JSON.stringify({
+      mcpServers: {
+        [PREVIEW_MCP_SERVER_NAME]: {
+          type: "http",
+          url: config.endpoint,
+          headers: { Authorization: config.authorizationHeader },
+        },
+      },
+    });
+  }
+}

--- a/apps/server/src/provider/Drivers/OmpDriver.ts
+++ b/apps/server/src/provider/Drivers/OmpDriver.ts
@@ -52,6 +52,7 @@ import {
   parseOmpModelRoleSlug,
   syncOmpSettingsToConfigStore,
 } from "../omp/index.ts";
+import { OmpPreviewMcpInjector } from "../../mcp/OmpPreviewMcpInjector.ts";
 import {
   defaultProviderContinuationIdentity,
   type ProviderDriver,
@@ -64,6 +65,7 @@ import type { ServerProviderShape } from "../Services/ServerProvider.ts";
 
 const decodeOmpSettings = Schema.decodeSync(OmpSettings);
 const DRIVER_KIND = ProviderDriverKind.make("omp");
+const PREVIEW_MCP_OVERLAY_DIRNAME = "pivot-preview-mcp";
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
 const OMP_PRESENTATION = {
@@ -482,9 +484,16 @@ export const OmpDriver: ProviderDriver<OmpSettings, OmpDriverEnv> = {
         resolveProjectCwd,
         listProjectWorkspaces,
       );
+      const previewMcpInjector = new OmpPreviewMcpInjector(
+        fs,
+        pathService,
+        pathService.join(NodeOS.tmpdir(), PREVIEW_MCP_OVERLAY_DIRNAME),
+      );
       const adapter = new OmpAdapter(runtime, randomUUID, {
         resolveRoleModel,
         capabilitiesService,
+        previewMcpInjector,
+        agentDir,
       });
       yield* Effect.addFinalizer(() => adapter.stopAll());
 

--- a/apps/server/src/provider/omp/FakeOmpRpc.ts
+++ b/apps/server/src/provider/omp/FakeOmpRpc.ts
@@ -62,7 +62,7 @@ export class FakeOmpRpc {
     readonly cwd: string;
     readonly resumeCursor: string | null;
     readonly extraEnv?: Record<string, string>;
-  }) {
+  }): Effect.Effect<{ sessionKey: string; sessionFile: string }, OmpSpawnError> {
     return Effect.gen({ self: this }, function* () {
       if (!this.frames.has(input.sessionKey)) {
         this.frames.set(input.sessionKey, yield* Queue.unbounded<object>());

--- a/apps/server/src/provider/omp/FakeOmpRpc.ts
+++ b/apps/server/src/provider/omp/FakeOmpRpc.ts
@@ -61,6 +61,7 @@ export class FakeOmpRpc {
     readonly sessionKey: string;
     readonly cwd: string;
     readonly resumeCursor: string | null;
+    readonly extraEnv?: Record<string, string>;
   }) {
     return Effect.gen({ self: this }, function* () {
       if (!this.frames.has(input.sessionKey)) {

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -29,11 +29,17 @@ import {
   setMcpProviderSession,
   type McpProviderSessionConfig,
 } from "../../mcp/McpProviderSession.ts";
-import { ProviderAdapterRequestError, ProviderAdapterSessionNotFoundError } from "../Errors.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+} from "../Errors.ts";
 const isProviderAdapterSessionNotFoundError = Schema.is(ProviderAdapterSessionNotFoundError);
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
+const isProviderAdapterProcessError = Schema.is(ProviderAdapterProcessError);
 import { FakeOmpRpc } from "./FakeOmpRpc.ts";
 import { OmpAdapter } from "./OmpAdapter.ts";
+import { OmpSpawnError } from "./OmpRpcRuntime.ts";
 
 let nextTestUuid = 0;
 const testRandomUUID = Effect.sync(() => {
@@ -63,6 +69,7 @@ type PreviewEnsureSessionInput = {
 class OverlayObservingFakeOmpRpc extends FakeOmpRpc {
   extraEnv: Record<string, string> | undefined;
   overlayExistedAtSpawn = false;
+  failEnsureSession = false;
   readonly #fileSystem: FileSystem.FileSystem;
   readonly #overlayMcpJsonPath: string;
 
@@ -77,6 +84,12 @@ class OverlayObservingFakeOmpRpc extends FakeOmpRpc {
     return Effect.gen({ self: this }, function* () {
       this.extraEnv = input.extraEnv;
       this.overlayExistedAtSpawn = yield* this.#fileSystem.exists(this.#overlayMcpJsonPath);
+      if (this.failEnsureSession) {
+        return yield* new OmpSpawnError({
+          operation: "ensureSession",
+          detail: "spawn failed",
+        });
+      }
       return yield* startSession;
     });
   }
@@ -1640,6 +1653,25 @@ describe("OmpAdapter", () => {
   );
 
   it.effect(
+    "Given get_available_models entries missing id, When discoverModels runs, Then ProviderAdapterRequestError names get_available_models",
+    () =>
+      Effect.gen(function* () {
+        const fake = new FakeOmpRpc();
+        fake.availableModels = [{ provider: "openai" }];
+        const adapter = new OmpAdapter(fake, testRandomUUID);
+        yield* adapter.startSession(startInput);
+
+        const error = yield* adapter.discoverModels(THREAD_ID).pipe(Effect.flip);
+
+        NodeAssert.equal(isProviderAdapterRequestError(error), true);
+        if (isProviderAdapterRequestError(error)) {
+          NodeAssert.equal(error.method, "get_available_models");
+          NodeAssert.equal(error.detail, "each model requires provider and id strings");
+        }
+      }),
+  );
+
+  it.effect(
     "discoverSlashCommands maps get_available_commands into ServerProviderSlashCommand",
     () =>
       Effect.gen(function* () {
@@ -2760,6 +2792,35 @@ describe("OmpAdapter preview MCP overlay", () => {
       }).pipe(
         Effect.ensuring(
           Effect.sync(() => clearMcpProviderSession(ThreadId.make("thread-preview-stop"))),
+        ),
+        Effect.provide(NodeServices.layer),
+      ),
+  );
+
+  it.effect(
+    "Given overlay install then spawn failure, When startSession fails, Then the overlay directory is gone",
+    () =>
+      Effect.gen(function* () {
+        const threadId = ThreadId.make("thread-preview-spawn-fail");
+        const { fs, overlayHome, fake, adapter } = yield* makePreviewHarness(threadId);
+        fake.failEnsureSession = true;
+        setMcpProviderSession(makePreviewSessionConfig(threadId));
+
+        const error = yield* adapter
+          .startSession({
+            threadId,
+            provider: PROVIDER,
+            cwd: "/proj",
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.flip);
+
+        NodeAssert.equal(fake.overlayExistedAtSpawn, true);
+        NodeAssert.equal(isProviderAdapterProcessError(error), true);
+        NodeAssert.equal(yield* fs.exists(overlayHome), false);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => clearMcpProviderSession(ThreadId.make("thread-preview-spawn-fail"))),
         ),
         Effect.provide(NodeServices.layer),
       ),

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -83,7 +83,9 @@ class OverlayObservingFakeOmpRpc extends FakeOmpRpc {
     const startSession = FakeOmpRpc.prototype.ensureSession.call(this, input);
     return Effect.gen({ self: this }, function* () {
       this.extraEnv = input.extraEnv;
-      this.overlayExistedAtSpawn = yield* this.#fileSystem.exists(this.#overlayMcpJsonPath);
+      this.overlayExistedAtSpawn = yield* this.#fileSystem
+        .exists(this.#overlayMcpJsonPath)
+        .pipe(Effect.orDie);
       if (this.failEnsureSession) {
         return yield* new OmpSpawnError({
           operation: "ensureSession",

--- a/apps/server/src/provider/omp/OmpAdapter.test.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.test.ts
@@ -1,8 +1,10 @@
 import * as NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   ApprovalRequestId,
+  EnvironmentId,
   type ProviderRuntimeEvent,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -14,11 +16,19 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { describe } from "vite-plus/test";
 
+import { OmpPreviewMcpInjector } from "../../mcp/OmpPreviewMcpInjector.ts";
+import {
+  clearMcpProviderSession,
+  setMcpProviderSession,
+  type McpProviderSessionConfig,
+} from "../../mcp/McpProviderSession.ts";
 import { ProviderAdapterRequestError, ProviderAdapterSessionNotFoundError } from "../Errors.ts";
 const isProviderAdapterSessionNotFoundError = Schema.is(ProviderAdapterSessionNotFoundError);
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
@@ -40,6 +50,37 @@ const startInput = {
   cwd: "/proj",
   runtimeMode: "full-access" as const,
 };
+
+const PREVIEW_AGENT_DIR = "/tmp/pivot-agent-dir";
+
+type PreviewEnsureSessionInput = {
+  readonly sessionKey: string;
+  readonly cwd: string;
+  readonly resumeCursor: string | null;
+  readonly extraEnv?: Record<string, string>;
+};
+
+class OverlayObservingFakeOmpRpc extends FakeOmpRpc {
+  extraEnv: Record<string, string> | undefined;
+  overlayExistedAtSpawn = false;
+  readonly #fileSystem: FileSystem.FileSystem;
+  readonly #overlayMcpJsonPath: string;
+
+  constructor(fileSystem: FileSystem.FileSystem, overlayMcpJsonPath: string) {
+    super();
+    this.#fileSystem = fileSystem;
+    this.#overlayMcpJsonPath = overlayMcpJsonPath;
+  }
+
+  override ensureSession(input: PreviewEnsureSessionInput) {
+    const startSession = FakeOmpRpc.prototype.ensureSession.call(this, input);
+    return Effect.gen({ self: this }, function* () {
+      this.extraEnv = input.extraEnv;
+      this.overlayExistedAtSpawn = yield* this.#fileSystem.exists(this.#overlayMcpJsonPath);
+      return yield* startSession;
+    });
+  }
+}
 
 const collectUntilTurnCompleted = (stream: Stream.Stream<ProviderRuntimeEvent>) =>
   Stream.runCollect(stream.pipe(Stream.takeUntil((event) => event.type === "turn.completed"))).pipe(
@@ -2621,5 +2662,106 @@ describe("OmpAdapter review mode", () => {
       NodeAssert.equal(enterReviewCommands[1]?.provider, "anthropic");
       NodeAssert.equal(enterReviewCommands[1]?.modelId, "claude-review");
     }),
+  );
+});
+
+describe("OmpAdapter preview MCP overlay", () => {
+  const makePreviewSessionConfig = (threadId: ThreadId): McpProviderSessionConfig => ({
+    environmentId: EnvironmentId.make("environment-1"),
+    threadId,
+    providerSessionId: "provider-session-preview",
+    providerInstanceId: ProviderInstanceId.make("omp"),
+    endpoint: "http://127.0.0.1:43123/mcp",
+    authorizationHeader: "Bearer test-preview-token",
+  });
+
+  const makePreviewHarness = (threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const overlayRoot = yield* fs.makeTempDirectoryScoped({ prefix: "pivot-preview-mcp-" });
+      const overlayHome = path.join(overlayRoot, threadId);
+      const overlayMcpJsonPath = path.join(overlayHome, ".cursor", "mcp.json");
+      const injector = new OmpPreviewMcpInjector(fs, path, overlayRoot);
+      const fake = new OverlayObservingFakeOmpRpc(fs, overlayMcpJsonPath);
+      const adapter = new OmpAdapter(fake, testRandomUUID, {
+        previewMcpInjector: injector,
+        agentDir: PREVIEW_AGENT_DIR,
+      });
+      return { fs, overlayHome, overlayMcpJsonPath, fake, adapter };
+    });
+
+  it.effect(
+    "Given a minted MCP session and injector, When startSession runs, Then the overlay exists before spawn and extraEnv is passed",
+    () =>
+      Effect.gen(function* () {
+        const threadId = ThreadId.make("thread-preview-inject");
+        const { overlayHome, fake, adapter } = yield* makePreviewHarness(threadId);
+        setMcpProviderSession(makePreviewSessionConfig(threadId));
+
+        yield* adapter.startSession({
+          threadId,
+          provider: PROVIDER,
+          cwd: "/proj",
+          runtimeMode: "full-access",
+        });
+
+        NodeAssert.equal(fake.overlayExistedAtSpawn, true);
+        NodeAssert.equal(fake.extraEnv?.HOME, overlayHome);
+        NodeAssert.equal(fake.extraEnv?.PI_CODING_AGENT_DIR, PREVIEW_AGENT_DIR);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => clearMcpProviderSession(ThreadId.make("thread-preview-inject"))),
+        ),
+        Effect.provide(NodeServices.layer),
+      ),
+  );
+
+  it.effect(
+    "Given no minted MCP session, When startSession runs, Then no overlay is written and extraEnv is omitted",
+    () =>
+      Effect.gen(function* () {
+        const threadId = ThreadId.make("thread-preview-login");
+        const { fs, overlayHome, overlayMcpJsonPath, fake, adapter } =
+          yield* makePreviewHarness(threadId);
+
+        yield* adapter.startSession({
+          threadId,
+          provider: PROVIDER,
+          cwd: "/proj",
+          runtimeMode: "full-access",
+        });
+
+        NodeAssert.equal(fake.overlayExistedAtSpawn, false);
+        NodeAssert.equal(fake.extraEnv, undefined);
+        NodeAssert.equal(yield* fs.exists(overlayMcpJsonPath), false);
+        NodeAssert.equal(yield* fs.exists(overlayHome), false);
+      }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect(
+    "Given an injected session, When stopSession runs, Then the overlay directory is gone",
+    () =>
+      Effect.gen(function* () {
+        const threadId = ThreadId.make("thread-preview-stop");
+        const { fs, overlayHome, fake, adapter } = yield* makePreviewHarness(threadId);
+        setMcpProviderSession(makePreviewSessionConfig(threadId));
+        yield* adapter.startSession({
+          threadId,
+          provider: PROVIDER,
+          cwd: "/proj",
+          runtimeMode: "full-access",
+        });
+        NodeAssert.equal(fake.overlayExistedAtSpawn, true);
+
+        yield* adapter.stopSession(threadId);
+
+        NodeAssert.equal(yield* fs.exists(overlayHome), false);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => clearMcpProviderSession(ThreadId.make("thread-preview-stop"))),
+        ),
+        Effect.provide(NodeServices.layer),
+      ),
   );
 });

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -26,6 +26,7 @@
  * @module provider/omp/OmpAdapter
  */
 import { ReviewBlockDecoder } from "./ReviewBlockDecoder.ts";
+import { OmpCatalogDecoder } from "./OmpCatalogDecoder.ts";
 import { formatOmpToolOutputText, OmpToolPresentation } from "./OmpToolPresentation.ts";
 import {
   type ApprovalRequestId,
@@ -39,8 +40,6 @@ import {
   RuntimeItemId,
   RuntimeRequestId,
   type RuntimeTaskStatus,
-  type ServerProviderModel,
-  type ServerProviderSlashCommand,
   ProviderDriverKind,
   ReviewFileLineCoverage,
   RuntimeTaskId,
@@ -119,13 +118,6 @@ function mapOmpSpawnError(threadId: ThreadId, cause: OmpSpawnError): ProviderAda
     detail: cause.message,
     cause,
   });
-}
-
-export interface OmpLoginProvider {
-  readonly id: string;
-  readonly name: string;
-  readonly available: boolean;
-  readonly authenticated: boolean;
 }
 
 export interface OmpOpenUrlRequest {
@@ -227,6 +219,7 @@ export class OmpAdapter {
   readonly #agentDir: string | undefined;
   readonly #reviewBlockDecoder = new ReviewBlockDecoder();
   readonly #toolPresentation = new OmpToolPresentation();
+  readonly #catalogDecoder = new OmpCatalogDecoder();
 
   public constructor(
     runtime: OmpRpcClient,
@@ -796,7 +789,7 @@ export class OmpAdapter {
       const response = yield* this.#send(threadId, {
         type: "get_available_models",
       });
-      return yield* modelsFromAvailableModelsResponse(response);
+      return yield* this.#catalogDecoder.decodeModels(response);
     });
   }
 
@@ -811,7 +804,7 @@ export class OmpAdapter {
       const response = yield* this.#send(threadId, {
         type: "get_available_commands",
       });
-      return yield* slashCommandsFromAvailableCommandsResponse(response);
+      return yield* this.#catalogDecoder.decodeSlashCommands(response);
     });
   }
 
@@ -826,7 +819,7 @@ export class OmpAdapter {
       const response = yield* this.#send(threadId, {
         type: "get_login_providers",
       });
-      return yield* loginProvidersFromResponse(response);
+      return yield* this.#catalogDecoder.decodeLoginProviders(response);
     });
   }
 
@@ -2102,126 +2095,6 @@ function runtimeTaskStatusFromOmpProgress(status: unknown): RuntimeTaskStatus | 
 
 function isLocalOnlyPromptResponse(response: object): boolean {
   return isRecord(response) && isRecord(response.data) && response.data.agentInvoked === false;
-}
-
-function loginProvidersFromResponse(
-  response: object,
-): Effect.Effect<ReadonlyArray<OmpLoginProvider>, ProviderAdapterRequestError> {
-  if (!isRecord(response) || !isRecord(response.data) || !Array.isArray(response.data.providers)) {
-    return Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: PROVIDER,
-        method: "get_login_providers",
-        detail: "response data.providers must be an array",
-      }),
-    );
-  }
-  const providers: OmpLoginProvider[] = [];
-  for (const entry of response.data.providers) {
-    if (
-      !isRecord(entry) ||
-      typeof entry.id !== "string" ||
-      typeof entry.name !== "string" ||
-      typeof entry.available !== "boolean" ||
-      typeof entry.authenticated !== "boolean"
-    ) {
-      return Effect.fail(
-        new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "get_login_providers",
-          detail: "each login provider requires id, name, available, authenticated",
-        }),
-      );
-    }
-    providers.push({
-      id: entry.id,
-      name: entry.name,
-      available: entry.available,
-      authenticated: entry.authenticated,
-    });
-  }
-  return Effect.succeed(providers);
-}
-
-function slashCommandsFromAvailableCommandsResponse(
-  response: object,
-): Effect.Effect<ReadonlyArray<ServerProviderSlashCommand>, ProviderAdapterRequestError> {
-  if (!isRecord(response) || !isRecord(response.data) || !Array.isArray(response.data.commands)) {
-    return Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: PROVIDER,
-        method: "get_available_commands",
-        detail: "response data.commands must be an array",
-      }),
-    );
-  }
-  const commands: ServerProviderSlashCommand[] = [];
-  for (const entry of response.data.commands) {
-    if (!isRecord(entry) || typeof entry.name !== "string" || entry.name.trim().length === 0) {
-      return Effect.fail(
-        new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "get_available_commands",
-          detail: "each command requires a non-empty name",
-        }),
-      );
-    }
-    const name = entry.name.trim().replace(/^\//, "");
-    const description =
-      typeof entry.description === "string" && entry.description.trim().length > 0
-        ? entry.description.trim()
-        : undefined;
-    const inputHint =
-      isRecord(entry.input) &&
-      typeof entry.input.hint === "string" &&
-      entry.input.hint.trim().length > 0
-        ? entry.input.hint.trim()
-        : undefined;
-    commands.push({
-      name,
-      ...(description === undefined ? {} : { description }),
-      ...(inputHint === undefined ? {} : { input: { hint: inputHint } }),
-    });
-  }
-  return Effect.succeed(commands);
-}
-
-function modelsFromAvailableModelsResponse(
-  response: object,
-): Effect.Effect<ReadonlyArray<ServerProviderModel>, ProviderAdapterRequestError> {
-  if (!isRecord(response) || !isRecord(response.data) || !Array.isArray(response.data.models)) {
-    return Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: PROVIDER,
-        method: "get_available_models",
-        detail: "response data.models must be an array",
-      }),
-    );
-  }
-  const models: ServerProviderModel[] = [];
-  for (const entry of response.data.models) {
-    if (!isRecord(entry) || typeof entry.provider !== "string" || typeof entry.id !== "string") {
-      return Effect.fail(
-        new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "get_available_models",
-          detail: "each model requires provider and id strings",
-        }),
-      );
-    }
-    const provider = entry.provider.trim();
-    const id = entry.id.trim();
-    const slug = `${provider}/${id}`;
-    const name =
-      typeof entry.name === "string" && entry.name.trim().length > 0 ? entry.name.trim() : slug;
-    models.push({
-      slug,
-      name,
-      isCustom: false,
-      capabilities: null,
-    });
-  }
-  return Effect.succeed(models);
 }
 
 const OMP_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;

--- a/apps/server/src/provider/omp/OmpAdapter.ts
+++ b/apps/server/src/provider/omp/OmpAdapter.ts
@@ -78,6 +78,8 @@ import type {
 } from "@t3tools/contracts";
 import type { OmpCapabilitiesService } from "./OmpCapabilitiesService.ts";
 import { OmpSpawnError, type OmpRpcRuntime } from "./OmpRpcRuntime.ts";
+import { OmpPreviewMcpInjector } from "../../mcp/OmpPreviewMcpInjector.ts";
+import { readMcpProviderSession } from "../../mcp/McpProviderSession.ts";
 
 const PROVIDER = ProviderDriverKind.make("omp");
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
@@ -189,6 +191,8 @@ export interface OmpAdapterOptions {
     | "deleteResource"
     | "moveItemToOmp"
   >;
+  readonly previewMcpInjector?: OmpPreviewMcpInjector;
+  readonly agentDir?: string;
 }
 
 export type OmpSubagentSubscriptionLevel = "off" | "progress" | "events";
@@ -219,6 +223,8 @@ export class OmpAdapter {
   readonly #randomUUID: Effect.Effect<string>;
   readonly #resolveRoleModel: OmpResolveRoleModel;
   readonly #capabilitiesService: OmpAdapterOptions["capabilitiesService"];
+  readonly #previewMcpInjector: OmpPreviewMcpInjector | undefined;
+  readonly #agentDir: string | undefined;
   readonly #reviewBlockDecoder = new ReviewBlockDecoder();
   readonly #toolPresentation = new OmpToolPresentation();
 
@@ -231,6 +237,8 @@ export class OmpAdapter {
     this.#randomUUID = randomUUID;
     this.#resolveRoleModel = options.resolveRoleModel ?? (() => Effect.succeed(undefined));
     this.#capabilitiesService = options.capabilitiesService;
+    this.#previewMcpInjector = options.previewMcpInjector;
+    this.#agentDir = options.agentDir;
   }
 
   private requireCapabilitiesService(): Effect.Effect<
@@ -316,13 +324,18 @@ export class OmpAdapter {
         });
       }
       const resumeCursor = typeof input.resumeCursor === "string" ? input.resumeCursor : null;
+      const extraEnv = yield* this.#installPreviewMcp(input.threadId);
       const handle = yield* this.#runtime
         .ensureSession({
           sessionKey: input.threadId,
           cwd,
           resumeCursor,
+          ...(extraEnv === undefined ? {} : { extraEnv }),
         })
-        .pipe(Effect.mapError((cause) => mapOmpSpawnError(input.threadId, cause)));
+        .pipe(
+          Effect.tapError(() => this.#uninstallPreviewMcp(input.threadId)),
+          Effect.mapError((cause) => mapOmpSpawnError(input.threadId, cause)),
+        );
       const createdAt = yield* nowIso;
       const scope = yield* Scope.make("sequential");
       const snapshot: ProviderSession = {
@@ -1859,6 +1872,7 @@ export class OmpAdapter {
 
   #clearLiveSession(threadId: ThreadId) {
     return Effect.gen({ self: this }, function* () {
+      yield* this.#uninstallPreviewMcp(threadId);
       const session = this.#sessions.get(threadId);
       this.#sessions.delete(threadId);
       if (session) {
@@ -1866,6 +1880,26 @@ export class OmpAdapter {
       }
       yield* this.#runtime.dispose(threadId);
     });
+  }
+
+  #installPreviewMcp(threadId: ThreadId): Effect.Effect<Record<string, string> | undefined> {
+    const injector = this.#previewMcpInjector;
+    const agentDir = this.#agentDir;
+    const mcp = readMcpProviderSession(threadId);
+    if (injector === undefined || agentDir === undefined || mcp === undefined) {
+      return Effect.succeed(undefined);
+    }
+    return injector
+      .install(threadId, mcp, agentDir)
+      .pipe(Effect.map((installed) => installed.extraEnv));
+  }
+
+  #uninstallPreviewMcp(threadId: ThreadId): Effect.Effect<void> {
+    const injector = this.#previewMcpInjector;
+    if (injector === undefined) {
+      return Effect.void;
+    }
+    return injector.uninstall(threadId);
   }
 
   #onExtensionUiRequest(

--- a/apps/server/src/provider/omp/OmpCatalogDecoder.test.ts
+++ b/apps/server/src/provider/omp/OmpCatalogDecoder.test.ts
@@ -1,0 +1,192 @@
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { describe } from "vite-plus/test";
+
+import { OmpCatalogDecoder } from "./OmpCatalogDecoder.ts";
+
+class CatalogRpcFixture {
+  static models(entries: ReadonlyArray<Record<string, unknown>>) {
+    return { data: { models: entries } };
+  }
+
+  static commands(entries: ReadonlyArray<Record<string, unknown>>) {
+    return { data: { commands: entries } };
+  }
+
+  static providers(entries: ReadonlyArray<Record<string, unknown>>) {
+    return { data: { providers: entries } };
+  }
+}
+
+describe("OmpCatalogDecoder", () => {
+  const decoder = new OmpCatalogDecoder();
+
+  it.effect(
+    "Given models with provider and id, When decodeModels runs, Then slugs are provider/id and name falls back to slug",
+    () =>
+      Effect.gen(function* () {
+        const models = yield* decoder.decodeModels(
+          CatalogRpcFixture.models([
+            { provider: "openai", id: "gpt-5", name: "GPT-5" },
+            { provider: " anthropic ", id: " claude-sonnet-4 " },
+          ]),
+        );
+
+        expect(models).toEqual([
+          { slug: "openai/gpt-5", name: "GPT-5", isCustom: false, capabilities: null },
+          {
+            slug: "anthropic/claude-sonnet-4",
+            name: "anthropic/claude-sonnet-4",
+            isCustom: false,
+            capabilities: null,
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "Given a response without data.models, When decodeModels runs, Then ProviderAdapterRequestError names get_available_models",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder.decodeModels({}).pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_available_models");
+        expect(error.detail).toBe("response data.models must be an array");
+      }),
+  );
+
+  it.effect(
+    "Given a model entry missing provider or id, When decodeModels runs, Then ProviderAdapterRequestError names the missing fields",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder
+          .decodeModels(CatalogRpcFixture.models([{ provider: "openai" }]))
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_available_models");
+        expect(error.detail).toBe("each model requires provider and id strings");
+      }),
+  );
+
+  it.effect(
+    "Given commands with a leading slash and optional hint, When decodeSlashCommands runs, Then names are unprefixed and empty description is omitted",
+    () =>
+      Effect.gen(function* () {
+        const commands = yield* decoder.decodeSlashCommands(
+          CatalogRpcFixture.commands([
+            {
+              name: "/model",
+              description: "Switch model",
+              input: { hint: "provider/model" },
+            },
+            { name: "  review  ", description: "   " },
+          ]),
+        );
+
+        expect(commands).toEqual([
+          {
+            name: "model",
+            description: "Switch model",
+            input: { hint: "provider/model" },
+          },
+          { name: "review" },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "Given a response without data.commands, When decodeSlashCommands runs, Then ProviderAdapterRequestError names get_available_commands",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder.decodeSlashCommands({}).pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_available_commands");
+        expect(error.detail).toBe("response data.commands must be an array");
+      }),
+  );
+
+  it.effect(
+    "Given a command with an empty name, When decodeSlashCommands runs, Then ProviderAdapterRequestError requires a non-empty name",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder
+          .decodeSlashCommands(CatalogRpcFixture.commands([{ name: "   " }]))
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_available_commands");
+        expect(error.detail).toBe("each command requires a non-empty name");
+      }),
+  );
+
+  it.effect(
+    "Given login providers with id name available authenticated, When decodeLoginProviders runs, Then those fields are returned",
+    () =>
+      Effect.gen(function* () {
+        const providers = yield* decoder.decodeLoginProviders(
+          CatalogRpcFixture.providers([
+            {
+              id: "openai-codex",
+              name: "ChatGPT Plus/Pro",
+              available: true,
+              authenticated: true,
+            },
+            {
+              id: "anthropic",
+              name: "Anthropic",
+              available: true,
+              authenticated: false,
+            },
+          ]),
+        );
+
+        expect(providers).toEqual([
+          {
+            id: "openai-codex",
+            name: "ChatGPT Plus/Pro",
+            available: true,
+            authenticated: true,
+          },
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            available: true,
+            authenticated: false,
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "Given a response without data.providers, When decodeLoginProviders runs, Then ProviderAdapterRequestError names get_login_providers",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder.decodeLoginProviders({}).pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_login_providers");
+        expect(error.detail).toBe("response data.providers must be an array");
+      }),
+  );
+
+  it.effect(
+    "Given a provider missing authenticated, When decodeLoginProviders runs, Then ProviderAdapterRequestError names the required fields",
+    () =>
+      Effect.gen(function* () {
+        const error = yield* decoder
+          .decodeLoginProviders(
+            CatalogRpcFixture.providers([{ id: "anthropic", name: "Anthropic", available: true }]),
+          )
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("ProviderAdapterRequestError");
+        expect(error.method).toBe("get_login_providers");
+        expect(error.detail).toBe(
+          "each login provider requires id, name, available, authenticated",
+        );
+      }),
+  );
+});

--- a/apps/server/src/provider/omp/OmpCatalogDecoder.test.ts
+++ b/apps/server/src/provider/omp/OmpCatalogDecoder.test.ts
@@ -1,192 +1,310 @@
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
 
+import { ProviderAdapterRequestError } from "../Errors.ts";
 import { OmpCatalogDecoder } from "./OmpCatalogDecoder.ts";
 
+const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
+
 class CatalogRpcFixture {
-  static models(entries: ReadonlyArray<Record<string, unknown>>) {
+  static model(overrides: Record<string, unknown> = {}) {
+    return { provider: "openai", id: "gpt-5", name: "GPT-5", ...overrides };
+  }
+
+  static modelsResponse(
+    entries: ReadonlyArray<Record<string, unknown>> = [CatalogRpcFixture.model()],
+  ) {
     return { data: { models: entries } };
   }
 
-  static commands(entries: ReadonlyArray<Record<string, unknown>>) {
+  static command(overrides: Record<string, unknown> = {}) {
+    return { name: "review", ...overrides };
+  }
+
+  static commandsResponse(
+    entries: ReadonlyArray<Record<string, unknown>> = [CatalogRpcFixture.command()],
+  ) {
     return { data: { commands: entries } };
   }
 
-  static providers(entries: ReadonlyArray<Record<string, unknown>>) {
+  static provider(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "anthropic",
+      name: "Anthropic",
+      available: true,
+      authenticated: false,
+      ...overrides,
+    };
+  }
+
+  static providersResponse(
+    entries: ReadonlyArray<Record<string, unknown>> = [CatalogRpcFixture.provider()],
+  ) {
     return { data: { providers: entries } };
   }
 }
 
+const expectRequestError = (error: unknown, method: string, detail: string) => {
+  expect(isProviderAdapterRequestError(error)).toBe(true);
+  if (!isProviderAdapterRequestError(error)) {
+    return;
+  }
+  expect(error.provider).toBe("omp");
+  expect(error.method).toBe(method);
+  expect(error.detail).toBe(detail);
+};
+
 describe("OmpCatalogDecoder", () => {
-  const decoder = new OmpCatalogDecoder();
+  describe("decodeModels", () => {
+    it.effect(
+      "Given padded provider and id, When decodeModels runs, Then the slug is trimmed provider/id",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-  it.effect(
-    "Given models with provider and id, When decodeModels runs, Then slugs are provider/id and name falls back to slug",
-    () =>
+          const models = yield* decoder.decodeModels(
+            CatalogRpcFixture.modelsResponse([
+              CatalogRpcFixture.model({ provider: " anthropic ", id: " claude-sonnet-4 " }),
+            ]),
+          );
+
+          expect(models).toMatchObject([
+            { slug: "anthropic/claude-sonnet-4", isCustom: false, capabilities: null },
+          ]);
+        }),
+    );
+
+    it.effect("Given a model with no name, When decodeModels runs, Then name equals the slug", () =>
       Effect.gen(function* () {
+        const decoder = new OmpCatalogDecoder();
+
         const models = yield* decoder.decodeModels(
-          CatalogRpcFixture.models([
-            { provider: "openai", id: "gpt-5", name: "GPT-5" },
-            { provider: " anthropic ", id: " claude-sonnet-4 " },
+          CatalogRpcFixture.modelsResponse([
+            CatalogRpcFixture.model({ id: "gpt-5", name: undefined }),
           ]),
         );
 
-        expect(models).toEqual([
-          { slug: "openai/gpt-5", name: "GPT-5", isCustom: false, capabilities: null },
-          {
-            slug: "anthropic/claude-sonnet-4",
-            name: "anthropic/claude-sonnet-4",
-            isCustom: false,
-            capabilities: null,
-          },
-        ]);
+        expect(models).toMatchObject([{ slug: "openai/gpt-5", name: "openai/gpt-5" }]);
       }),
-  );
+    );
 
-  it.effect(
-    "Given a response without data.models, When decodeModels runs, Then ProviderAdapterRequestError names get_available_models",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder.decodeModels({}).pipe(Effect.flip);
+    it.effect(
+      "Given an empty models array, When decodeModels runs, Then the catalog is empty",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_available_models");
-        expect(error.detail).toBe("response data.models must be an array");
-      }),
-  );
+          const models = yield* decoder.decodeModels(CatalogRpcFixture.modelsResponse([]));
 
-  it.effect(
-    "Given a model entry missing provider or id, When decodeModels runs, Then ProviderAdapterRequestError names the missing fields",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder
-          .decodeModels(CatalogRpcFixture.models([{ provider: "openai" }]))
-          .pipe(Effect.flip);
+          expect(models).toEqual([]);
+        }),
+    );
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_available_models");
-        expect(error.detail).toBe("each model requires provider and id strings");
-      }),
-  );
+    it.effect(
+      "Given a response without data.models, When decodeModels runs, Then ProviderAdapterRequestError names get_available_models",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-  it.effect(
-    "Given commands with a leading slash and optional hint, When decodeSlashCommands runs, Then names are unprefixed and empty description is omitted",
-    () =>
-      Effect.gen(function* () {
-        const commands = yield* decoder.decodeSlashCommands(
-          CatalogRpcFixture.commands([
-            {
-              name: "/model",
-              description: "Switch model",
-              input: { hint: "provider/model" },
-            },
-            { name: "  review  ", description: "   " },
-          ]),
-        );
+          const error = yield* decoder.decodeModels({}).pipe(Effect.flip);
 
-        expect(commands).toEqual([
-          {
-            name: "model",
-            description: "Switch model",
-            input: { hint: "provider/model" },
-          },
-          { name: "review" },
-        ]);
-      }),
-  );
+          expectRequestError(
+            error,
+            "get_available_models",
+            "response data.models must be an array",
+          );
+        }),
+    );
 
-  it.effect(
-    "Given a response without data.commands, When decodeSlashCommands runs, Then ProviderAdapterRequestError names get_available_commands",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder.decodeSlashCommands({}).pipe(Effect.flip);
+    it.effect(
+      "Given a model missing id, When decodeModels runs, Then ProviderAdapterRequestError requires provider and id",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_available_commands");
-        expect(error.detail).toBe("response data.commands must be an array");
-      }),
-  );
+          const error = yield* decoder
+            .decodeModels(CatalogRpcFixture.modelsResponse([CatalogRpcFixture.model({ id: 1 })]))
+            .pipe(Effect.flip);
 
-  it.effect(
-    "Given a command with an empty name, When decodeSlashCommands runs, Then ProviderAdapterRequestError requires a non-empty name",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder
-          .decodeSlashCommands(CatalogRpcFixture.commands([{ name: "   " }]))
-          .pipe(Effect.flip);
+          expectRequestError(
+            error,
+            "get_available_models",
+            "each model requires provider and id strings",
+          );
+        }),
+    );
+  });
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_available_commands");
-        expect(error.detail).toBe("each command requires a non-empty name");
-      }),
-  );
+  describe("decodeSlashCommands", () => {
+    it.effect(
+      "Given a command name with a leading slash, When decodeSlashCommands runs, Then the name is unprefixed",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-  it.effect(
-    "Given login providers with id name available authenticated, When decodeLoginProviders runs, Then those fields are returned",
-    () =>
-      Effect.gen(function* () {
-        const providers = yield* decoder.decodeLoginProviders(
-          CatalogRpcFixture.providers([
-            {
-              id: "openai-codex",
-              name: "ChatGPT Plus/Pro",
-              available: true,
-              authenticated: true,
-            },
+          const commands = yield* decoder.decodeSlashCommands(
+            CatalogRpcFixture.commandsResponse([CatalogRpcFixture.command({ name: "/model" })]),
+          );
+
+          expect(commands).toMatchObject([{ name: "model" }]);
+        }),
+    );
+
+    it.effect(
+      "Given a whitespace-only description, When decodeSlashCommands runs, Then description is omitted",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const commands = yield* decoder.decodeSlashCommands(
+            CatalogRpcFixture.commandsResponse([CatalogRpcFixture.command({ description: "   " })]),
+          );
+
+          expect(commands).toEqual([{ name: "review" }]);
+        }),
+    );
+
+    it.effect(
+      "Given an input hint, When decodeSlashCommands runs, Then the command keeps that hint",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const commands = yield* decoder.decodeSlashCommands(
+            CatalogRpcFixture.commandsResponse([
+              CatalogRpcFixture.command({ input: { hint: "provider/model" } }),
+            ]),
+          );
+
+          expect(commands).toMatchObject([{ name: "review", input: { hint: "provider/model" } }]);
+        }),
+    );
+
+    it.effect(
+      "Given an empty commands array, When decodeSlashCommands runs, Then the catalog is empty",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const commands = yield* decoder.decodeSlashCommands(
+            CatalogRpcFixture.commandsResponse([]),
+          );
+
+          expect(commands).toEqual([]);
+        }),
+    );
+
+    it.effect(
+      "Given a response without data.commands, When decodeSlashCommands runs, Then ProviderAdapterRequestError names get_available_commands",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const error = yield* decoder.decodeSlashCommands({}).pipe(Effect.flip);
+
+          expectRequestError(
+            error,
+            "get_available_commands",
+            "response data.commands must be an array",
+          );
+        }),
+    );
+
+    it.effect(
+      "Given a command with an empty name, When decodeSlashCommands runs, Then ProviderAdapterRequestError requires a non-empty name",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const error = yield* decoder
+            .decodeSlashCommands(
+              CatalogRpcFixture.commandsResponse([CatalogRpcFixture.command({ name: "   " })]),
+            )
+            .pipe(Effect.flip);
+
+          expectRequestError(
+            error,
+            "get_available_commands",
+            "each command requires a non-empty name",
+          );
+        }),
+    );
+  });
+
+  describe("decodeLoginProviders", () => {
+    it.effect(
+      "Given an unauthenticated provider, When decodeLoginProviders runs, Then authenticated stays false",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const providers = yield* decoder.decodeLoginProviders(
+            CatalogRpcFixture.providersResponse(),
+          );
+
+          expect(providers).toEqual([
             {
               id: "anthropic",
               name: "Anthropic",
               available: true,
               authenticated: false,
             },
-          ]),
-        );
+          ]);
+        }),
+    );
 
-        expect(providers).toEqual([
-          {
-            id: "openai-codex",
-            name: "ChatGPT Plus/Pro",
-            available: true,
-            authenticated: true,
-          },
-          {
-            id: "anthropic",
-            name: "Anthropic",
-            available: true,
-            authenticated: false,
-          },
-        ]);
-      }),
-  );
+    it.effect(
+      "Given an empty providers array, When decodeLoginProviders runs, Then the catalog is empty",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-  it.effect(
-    "Given a response without data.providers, When decodeLoginProviders runs, Then ProviderAdapterRequestError names get_login_providers",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder.decodeLoginProviders({}).pipe(Effect.flip);
+          const providers = yield* decoder.decodeLoginProviders(
+            CatalogRpcFixture.providersResponse([]),
+          );
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_login_providers");
-        expect(error.detail).toBe("response data.providers must be an array");
-      }),
-  );
+          expect(providers).toEqual([]);
+        }),
+    );
 
-  it.effect(
-    "Given a provider missing authenticated, When decodeLoginProviders runs, Then ProviderAdapterRequestError names the required fields",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* decoder
-          .decodeLoginProviders(
-            CatalogRpcFixture.providers([{ id: "anthropic", name: "Anthropic", available: true }]),
-          )
-          .pipe(Effect.flip);
+    it.effect(
+      "Given a response without data.providers, When decodeLoginProviders runs, Then ProviderAdapterRequestError names get_login_providers",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
 
-        expect(error._tag).toBe("ProviderAdapterRequestError");
-        expect(error.method).toBe("get_login_providers");
-        expect(error.detail).toBe(
-          "each login provider requires id, name, available, authenticated",
-        );
-      }),
-  );
+          const error = yield* decoder.decodeLoginProviders({}).pipe(Effect.flip);
+
+          expectRequestError(
+            error,
+            "get_login_providers",
+            "response data.providers must be an array",
+          );
+        }),
+    );
+
+    it.effect(
+      "Given a provider missing authenticated, When decodeLoginProviders runs, Then ProviderAdapterRequestError names the required fields",
+      () =>
+        Effect.gen(function* () {
+          const decoder = new OmpCatalogDecoder();
+
+          const error = yield* decoder
+            .decodeLoginProviders(
+              CatalogRpcFixture.providersResponse([
+                CatalogRpcFixture.provider({ authenticated: undefined }),
+              ]),
+            )
+            .pipe(Effect.flip);
+
+          expectRequestError(
+            error,
+            "get_login_providers",
+            "each login provider requires id, name, available, authenticated",
+          );
+        }),
+    );
+  });
 });

--- a/apps/server/src/provider/omp/OmpCatalogDecoder.ts
+++ b/apps/server/src/provider/omp/OmpCatalogDecoder.ts
@@ -1,0 +1,158 @@
+/**
+ * Decodes omp catalog RPC payloads: available models, slash commands, and
+ * login providers. The adapter owns session send; this class owns the map.
+ *
+ * @module provider/omp/OmpCatalogDecoder
+ */
+import {
+  ProviderDriverKind,
+  type ServerProviderModel,
+  type ServerProviderSlashCommand,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { ProviderAdapterRequestError } from "../Errors.ts";
+
+const PROVIDER = ProviderDriverKind.make("omp");
+
+export interface OmpLoginProvider {
+  readonly id: string;
+  readonly name: string;
+  readonly available: boolean;
+  readonly authenticated: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Maps `get_available_models`, `get_available_commands`, and
+ * `get_login_providers` RPC bodies onto the catalog types Settings and the
+ * composer consume.
+ */
+export class OmpCatalogDecoder {
+  decodeModels(
+    response: object,
+  ): Effect.Effect<ReadonlyArray<ServerProviderModel>, ProviderAdapterRequestError> {
+    if (!isRecord(response) || !isRecord(response.data) || !Array.isArray(response.data.models)) {
+      return Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "get_available_models",
+          detail: "response data.models must be an array",
+        }),
+      );
+    }
+    const models: ServerProviderModel[] = [];
+    for (const entry of response.data.models) {
+      if (!isRecord(entry) || typeof entry.provider !== "string" || typeof entry.id !== "string") {
+        return Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "get_available_models",
+            detail: "each model requires provider and id strings",
+          }),
+        );
+      }
+      const provider = entry.provider.trim();
+      const id = entry.id.trim();
+      const slug = `${provider}/${id}`;
+      const name =
+        typeof entry.name === "string" && entry.name.trim().length > 0 ? entry.name.trim() : slug;
+      models.push({
+        slug,
+        name,
+        isCustom: false,
+        capabilities: null,
+      });
+    }
+    return Effect.succeed(models);
+  }
+
+  decodeSlashCommands(
+    response: object,
+  ): Effect.Effect<ReadonlyArray<ServerProviderSlashCommand>, ProviderAdapterRequestError> {
+    if (!isRecord(response) || !isRecord(response.data) || !Array.isArray(response.data.commands)) {
+      return Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "get_available_commands",
+          detail: "response data.commands must be an array",
+        }),
+      );
+    }
+    const commands: ServerProviderSlashCommand[] = [];
+    for (const entry of response.data.commands) {
+      if (!isRecord(entry) || typeof entry.name !== "string" || entry.name.trim().length === 0) {
+        return Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "get_available_commands",
+            detail: "each command requires a non-empty name",
+          }),
+        );
+      }
+      const name = entry.name.trim().replace(/^\//, "");
+      const description =
+        typeof entry.description === "string" && entry.description.trim().length > 0
+          ? entry.description.trim()
+          : undefined;
+      const inputHint =
+        isRecord(entry.input) &&
+        typeof entry.input.hint === "string" &&
+        entry.input.hint.trim().length > 0
+          ? entry.input.hint.trim()
+          : undefined;
+      commands.push({
+        name,
+        ...(description === undefined ? {} : { description }),
+        ...(inputHint === undefined ? {} : { input: { hint: inputHint } }),
+      });
+    }
+    return Effect.succeed(commands);
+  }
+
+  decodeLoginProviders(
+    response: object,
+  ): Effect.Effect<ReadonlyArray<OmpLoginProvider>, ProviderAdapterRequestError> {
+    if (
+      !isRecord(response) ||
+      !isRecord(response.data) ||
+      !Array.isArray(response.data.providers)
+    ) {
+      return Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "get_login_providers",
+          detail: "response data.providers must be an array",
+        }),
+      );
+    }
+    const providers: OmpLoginProvider[] = [];
+    for (const entry of response.data.providers) {
+      if (
+        !isRecord(entry) ||
+        typeof entry.id !== "string" ||
+        typeof entry.name !== "string" ||
+        typeof entry.available !== "boolean" ||
+        typeof entry.authenticated !== "boolean"
+      ) {
+        return Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "get_login_providers",
+            detail: "each login provider requires id, name, available, authenticated",
+          }),
+        );
+      }
+      providers.push({
+        id: entry.id,
+        name: entry.name,
+        available: entry.available,
+        authenticated: entry.authenticated,
+      });
+    }
+    return Effect.succeed(providers);
+  }
+}

--- a/apps/server/src/provider/omp/OmpLogin.ts
+++ b/apps/server/src/provider/omp/OmpLogin.ts
@@ -7,7 +7,8 @@ import { ProviderDriverKind, ThreadId } from "@t3tools/contracts";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 
-import type { OmpAdapter, OmpLoginProvider, OmpOpenUrlRequest } from "./OmpAdapter.ts";
+import type { OmpAdapter, OmpOpenUrlRequest } from "./OmpAdapter.ts";
+import type { OmpLoginProvider } from "./OmpCatalogDecoder.ts";
 
 const PROVIDER = ProviderDriverKind.make("omp");
 

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -379,11 +379,13 @@ describe("OmpRpcRuntime", () => {
   );
 
   it.effect(
-    "Given extraEnv on ensureSession, When the session child spawns, Then spawn env contains HOME and PI_CODING_AGENT_DIR",
+    "Given settings HOME and extraEnv HOME, When the session child spawns, Then extraEnv HOME wins",
     () =>
       Effect.gen(function* () {
         const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
-        const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+        const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp", {
+          environment: [{ name: "HOME", value: "/from-settings", sensitive: false }],
+        });
         yield* runtime.ensureSession({
           sessionKey: "thread-1",
           cwd: "/proj",

--- a/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.test.ts
@@ -378,6 +378,28 @@ describe("OmpRpcRuntime", () => {
     }),
   );
 
+  it.effect(
+    "Given extraEnv on ensureSession, When the session child spawns, Then spawn env contains HOME and PI_CODING_AGENT_DIR",
+    () =>
+      Effect.gen(function* () {
+        const fake = makeFakeOmpSpawner({ sessionFile: "/tmp/omp-session.jsonl" });
+        const runtime = new OmpRpcRuntime(fake.spawner, "/opt/omp");
+        yield* runtime.ensureSession({
+          sessionKey: "thread-1",
+          cwd: "/proj",
+          resumeCursor: null,
+          extraEnv: {
+            HOME: "/tmp/x",
+            PI_CODING_AGENT_DIR: "/tmp/agent",
+          },
+        });
+        const sessionSpawn = fake.spawns.find((spawn) => hasModeRpcUi(spawn.args));
+        NodeAssert.ok(sessionSpawn);
+        NodeAssert.equal(sessionSpawn?.options.env?.HOME, "/tmp/x");
+        NodeAssert.equal(sessionSpawn?.options.env?.PI_CODING_AGENT_DIR, "/tmp/agent");
+      }),
+  );
+
   it.effect("fails closed when the omp binary does not advertise rpc-ui", () =>
     Effect.gen(function* () {
       const fake = makeFakeOmpSpawner({

--- a/apps/server/src/provider/omp/OmpRpcRuntime.ts
+++ b/apps/server/src/provider/omp/OmpRpcRuntime.ts
@@ -171,6 +171,7 @@ export interface OmpEnsureSessionInput {
   readonly sessionKey: string;
   readonly cwd: string;
   readonly resumeCursor: string | null;
+  readonly extraEnv?: Record<string, string>;
 }
 
 export interface OmpSessionHandle {
@@ -233,9 +234,13 @@ export class OmpRpcRuntime {
 
   /**
    * Env overrides for `ChildProcess.make` with `extendEnv: true`: settings
-   * vars first, then PATH when path-prefix dirs are configured (PATH wins).
+   * vars first, then PATH when path-prefix dirs are configured (PATH wins),
+   * then session `extraEnv` last (`HOME` / `PI_CODING_AGENT_DIR` win).
    */
-  #childEnvOverrides(platform: NodeJS.Platform): Record<string, string> | undefined {
+  #childEnvOverrides(
+    platform: NodeJS.Platform,
+    extraEnv?: Record<string, string>,
+  ): Record<string, string> | undefined {
     const preferredPath =
       this.#pathPrefixDirs.length > 0
         ? this.#pathPrefixDirs.join(platform === "win32" ? ";" : ":")
@@ -250,6 +255,11 @@ export class OmpRpcRuntime {
     }
     if (mergedPath !== undefined) {
       env.PATH = mergedPath;
+    }
+    if (extraEnv !== undefined) {
+      for (const [key, value] of Object.entries(extraEnv)) {
+        env[key] = value;
+      }
     }
     return Object.keys(env).length > 0 ? env : undefined;
   }
@@ -283,7 +293,7 @@ export class OmpRpcRuntime {
       }
 
       const platform = yield* HostProcessPlatform;
-      const env = this.#childEnvOverrides(platform);
+      const env = this.#childEnvOverrides(platform, input.extraEnv);
       const scope = yield* Scope.make();
       const child = yield* this.#processSpawner
         .spawn(

--- a/apps/server/src/provider/omp/index.ts
+++ b/apps/server/src/provider/omp/index.ts
@@ -18,3 +18,5 @@ export {
 export { makeRtkManagedBinary, RtkManagedBinaryError } from "./RtkManagedBinary.ts";
 export { ReviewBlockDecoder } from "./ReviewBlockDecoder.ts";
 export { OmpToolPresentation } from "./OmpToolPresentation.ts";
+export { OmpCatalogDecoder } from "./OmpCatalogDecoder.ts";
+export type { OmpLoginProvider } from "./OmpCatalogDecoder.ts";

--- a/docs/user/providers-omp.md
+++ b/docs/user/providers-omp.md
@@ -2,6 +2,8 @@
 
 Pivot drives [omp](https://omp.sh) over `omp --mode rpc-ui`. omp is the only built-in agent backend.
 
+omp project threads can use Pivot's in-app collaborative browser automatically; you do not add an MCP server.
+
 ## Install
 
 1. Open **Settings → omp** and click **Install**. Pivot downloads a managed omp binary into the T3 home (`tools/omp/`), then downloads managed [rtk](https://github.com/rtk-ai/rtk) into `tools/rtk/` and runs `rtk init -g --agent pi` so bash rewrite hooks are active for omp.


### PR DESCRIPTION
## What Changed

- omp project threads get Pivot `/mcp` as process-private HTTP MCP `pivot-preview` (overlay `HOME` + `PI_CODING_AGENT_DIR`).
- Session `extraEnv` merges last so overlay `HOME` wins over settings.
- Login probes skip inject when there is no minted session; overlay is deleted on stop and spawn failure.
- `OmpCatalogDecoder` maps `get_available_models` / `get_available_commands` / `get_login_providers`; `OmpAdapter` still sends those RPCs.

## Why

omp has no RPC `mcpServers`. Without child inject, `preview_*` never reaches the in-app collaborative browser. The overlay is process-private so user and project `mcp.json` never hold the bearer.

## UI Changes

N/A. omp project threads can open the in-app collaborative browser without adding an MCP server.

Closes #25